### PR TITLE
Crunz issue #11 (Debugging enhancement)

### DIFF
--- a/phpunit.php
+++ b/phpunit.php
@@ -28,3 +28,5 @@ require __DIR__ . '/vendor/autoload.php';
 date_default_timezone_set('UTC');
 
 Carbon\Carbon::setTestNow(Carbon\Carbon::now());
+
+putenv('CRUNZ_HOME=' . rtrim(getcwd(), '/'));

--- a/src/Console/Commands/ScheduleListCommand.php
+++ b/src/Console/Commands/ScheduleListCommand.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Finder\Finder;
+use Crunz\TaskfileFinder;
 
 use Crunz\Schedule;
 
@@ -66,7 +66,7 @@ class ScheduleListCommand extends Command
         $this->arguments = $input->getArguments();
         $src             = $this->arguments['source'];
         
-        $task_files      = $this->collectFiles($src); 
+        $task_files      = TaskfileFinder::collectFiles($src); 
     
         if (!count($task_files)) {
             $output->writeln('<comment>No task found!</comment>');
@@ -98,26 +98,6 @@ class ScheduleListCommand extends Command
         }
 
         $table->render(); 
-    }
- 
-    /**
-    * Collect all task files
-    *
-    * @param  string $source
-    * @return Iterator
-    */
-    public static function collectFiles($source)
-    {    
-        if(!file_exists($source)) {
-            return [];
-        }
-        
-        $finder   = new Finder();
-        $iterator = $finder->files()
-                  ->name('*Tasks.php')
-                  ->in($source);
-        
-        return $iterator;
     }
   
 }

--- a/src/Console/Commands/ScheduleRunCommand.php
+++ b/src/Console/Commands/ScheduleRunCommand.php
@@ -37,12 +37,20 @@ class ScheduleRunCommand extends Command
 
         'src' => '/tasks',
     ];
+	
+	/**
+     * Console Output
+     *
+     * @var Symfony\Component\Console\Input\OutputIterface $output
+     */
+	protected $output;
+	
 
     /**
      * Configures the current command
      *
      */
-     protected function configure()
+    protected function configure()
      {
         $this->setName('schedule:run')
              ->setDescription('Start the scheduler')
@@ -68,25 +76,61 @@ class ScheduleRunCommand extends Command
         $this->options   = $input->getOptions();
         $src             = $this->arguments['source'];
         $task_files      = TaskfileFinder::collectFiles($src); 
-		$task			 = $this->options['task']; 
-				    
-        if (!count($task_files)) {
-            $output->writeln('<comment>No task found!</comment>');
-            exit();
-        }
+		$requsted_task	 = $this->options['task']; 
+		$force			 = (bool) $this->options['force']; 
+		$this->output	 = $output;
 		
-        $running_events = [];
-        
-        foreach ($task_files as $key => $taskFile) {
-                        
-            $schedule = require $taskFile->getRealPath();            
-            if (!$schedule instanceof Schedule) {
-                continue;
-            } 
+		$events = $this->getEvents($task_files, $requsted_task, $force);
+		$this->runEvents($events);        
+      
+    }
+	
+		/**
+		 * Gets all the events
+		 *
+		 * @param $task_files
+		 * @param $requsted_task If this is set the method only return the requested task
+		 * @param $force If true, this method returns all events otherwise it only returns due events
+		 *
+		 * @return array Returns all the events as requested
+		 */
+		protected function getEvents($task_files, $requsted_task, $force) {
+		  if (!count($task_files))
+		  {
+			$this->outputComment('No task found!');
+		  }
 
-            $events = $schedule->dueEvents(new Invoker());   
-		foreach ($events as $event) {
-				
+		foreach ($task_files as $taskFile) {
+
+		  $schedule = require $taskFile->getRealPath();
+			if (!$schedule instanceof Schedule)
+			{
+			  continue;
+			}
+
+			$events = $schedule->events();
+			$dueEvents = $schedule->dueEvents(new Invoker());
+
+		}
+		if($requsted_task !== null) {
+		  return $this->getTask($events, $dueEvents, $requsted_task, $force);
+		}
+		else {
+		  return ($force) ? $events : $dueEvents;
+		}
+
+	  }
+  
+  /**
+     * Runs all the events
+     *
+     * @param $events
+     * @return void
+     */
+  protected function runEvents($events) {
+	  $running_events = [];
+	  foreach ($events as $event) {
+		 		
                 echo '[', date('Y-m-d H:i:s'), '] Running scheduled command: ', $event->getSummaryForDisplay(), PHP_EOL;
                 echo $event->buildCommand(), PHP_EOL;
                 echo '---', PHP_EOL;
@@ -95,11 +139,9 @@ class ScheduleRunCommand extends Command
                 $running_events[] = $event->callBeforeCallbacks(new Invoker())
                                           ->run(new Invoker());   
 		}
-        }
 		
-        if (!count($running_events)) {
-            $output->writeln('<comment>No task is due!</comment>');
-            exit();
+        if (!count($running_events)) {		  
+			$this->outputComment('No task is due!');
         }
 
         // Running the post-execution hooks
@@ -113,6 +155,38 @@ class ScheduleRunCommand extends Command
                 unset($running_events[$key]);
             }
         }
-    }
+	}
+	
+	/**
+     * Gets the requested task
+     *
+     * @param $events  All available events
+     * @param $dueEvents  All due events
+	 * @param $requested_task The number of requested task, as it is listed using schedule:list
+     *
+     * @return array Returns the requested event, exit with error message otherwise
+     */
+	protected function getTask($events, $dueEvents, $requsted_task, $force) {
+		if (empty($events[$requsted_task - 1]))
+		{
+		  $this->outputComment('The requested task does not exists.');
+		}
+		elseif (!empty($events[$requsted_task - 1]) && empty($dueEvents[$requsted_task - 1]) && !$force)
+		{
+		  $this->outputComment('The requested task exists but it is not due.');
+		}
+		else
+		{
+		  return [$events[$requsted_task - 1]];
+		}
+  }
   
+	protected function outputComment($comment = '') {
+	if (isset($this->output))
+	{
+	  $this->output->writeln("<comment>$comment</comment>");
+	}
+	exit();
+  }
+
 }

--- a/src/Console/Commands/ScheduleRunCommand.php
+++ b/src/Console/Commands/ScheduleRunCommand.php
@@ -8,185 +8,188 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Crunz\TaskfileFinder;
-
 use Crunz\Schedule;
 use Crunz\Invoker;
 
 class ScheduleRunCommand extends Command
 {
-    /**
-     * Command arguments
-     *
-     * @var array
-     */
-    protected $arguments;
-
-    /**
-     * Command options
-     *
-     * @var array
-     */
-    protected $options;
-
-    /**
-     * Default option values
-     *
-     * @var array
-     */
-    protected $defaults = [
-
-        'src' => '/tasks',
-    ];
-	
 	/**
-     * Console Output
-     *
-     * @var Symfony\Component\Console\Input\OutputIterface $output
-     */
-	protected $output;
-	
+	 * Command arguments
+	 *
+	 * @var array
+	 */
+	protected $arguments;
 
-    /**
-     * Configures the current command
-     *
-     */
-    protected function configure()
-     {
-        $this->setName('schedule:run')
-             ->setDescription('Start the scheduler')
-             ->setDefinition([
-                new InputArgument('source', InputArgument::OPTIONAL, 'The source directory to collect the tasks.', getenv('CRUNZ_HOME') . $this->defaults['src']),
-				new InputOption('task', '-t', InputOption::VALUE_OPTIONAL, 'The task to run from the list.', null), 
-				new InputOption('force', '-f', InputOption::VALUE_NONE, 'The command will run instantly.', null), 
-            ])
-             ->setHelp('This command starts the scheduler.');
-     } 
-   
-    /**
-     * Executes the current command
-     *
-     * @param use Symfony\Component\Console\Input\InputInterface $input
-     * @param use Symfony\Component\Console\Input\OutputIterface $output
-     *
-     * @return null|int null or 0 if everything went fine, or an error code
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {        
-        $this->arguments = $input->getArguments();
-        $this->options   = $input->getOptions();
-        $src             = $this->arguments['source'];
-        $task_files      = TaskfileFinder::collectFiles($src); 
-		$requsted_task	 = $this->options['task']; 
-		$force			 = (bool) $this->options['force']; 
-		$this->output	 = $output;
-		
+	/**
+	 * Command options
+	 *
+	 * @var array
+	 */
+	protected $options;
+
+	/**
+	 * Default option values
+	 *
+	 * @var array
+	 */
+	protected $defaults = [
+
+		'src' => '/tasks',
+	];
+
+	/**
+	 * Console Output
+	 *
+	 * @var Symfony\Component\Console\Input\OutputIterface $output
+	 */
+	protected $output;
+
+	/**
+	 * Configures the current command
+	 *
+	 */
+	protected function configure()
+	{
+		$this->setName('schedule:run')
+				->setDescription('Start the scheduler')
+				->setDefinition([
+					new InputArgument('source', InputArgument::OPTIONAL, 'The source directory to collect the tasks.', getenv('CRUNZ_HOME') . $this->defaults['src']),
+					new InputOption('task', '-t', InputOption::VALUE_OPTIONAL, 'The task to run from the list.', null),
+					new InputOption('force', '-f', InputOption::VALUE_NONE, 'The command will run instantly.', null),
+				])
+				->setHelp('This command starts the scheduler.');
+	}
+
+	/**
+	 * Executes the current command
+	 *
+	 * @param use Symfony\Component\Console\Input\InputInterface $input
+	 * @param use Symfony\Component\Console\Input\OutputIterface $output
+	 *
+	 * @return null|int null or 0 if everything went fine, or an error code
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output)
+	{
+		$this->arguments = $input->getArguments();
+		$this->options = $input->getOptions();
+		$src = $this->arguments['source'];
+		$task_files = TaskfileFinder::collectFiles($src);
+		$requsted_task = $this->options['task'];
+		$force = (bool) $this->options['force'];
+		$this->output = $output;
+
 		$events = $this->getEvents($task_files, $requsted_task, $force);
-		$this->runEvents($events);        
-      
-    }
-	
-		/**
-		 * Gets all the events
-		 *
-		 * @param $task_files
-		 * @param $requsted_task If this is set the method only return the requested task
-		 * @param $force If true, this method returns all events otherwise it only returns due events
-		 *
-		 * @return array Returns all the events as requested
-		 */
-		protected function getEvents($task_files, $requsted_task, $force) {
-		  if (!count($task_files))
-		  {
+		$this->runEvents($events);
+	}
+
+	/**
+	 * Gets all the events
+	 *
+	 * @param $task_files
+	 * @param $requsted_task If this is set the method only return the requested task
+	 * @param $force If true, this method returns all events otherwise it only returns due events
+	 *
+	 * @return array Returns all the events as requested
+	 */
+	protected function getEvents($task_files, $requsted_task, $force)
+	{
+		if (!count($task_files))
+		{
 			$this->outputComment('No task found!');
-		  }
+		}
 
 		foreach ($task_files as $taskFile) {
 
-		  $schedule = require $taskFile->getRealPath();
+			$schedule = require $taskFile->getRealPath();
 			if (!$schedule instanceof Schedule)
 			{
-			  continue;
+				continue;
 			}
 
 			$events = $schedule->events();
 			$dueEvents = $schedule->dueEvents(new Invoker());
-
 		}
-		if($requsted_task !== null) {
-		  return $this->getTask($events, $dueEvents, $requsted_task, $force);
-		}
-		else {
-		  return ($force) ? $events : $dueEvents;
-		}
-
-	  }
-  
-  /**
-     * Runs all the events
-     *
-     * @param $events
-     * @return void
-     */
-  protected function runEvents($events) {
-	  $running_events = [];
-	  foreach ($events as $event) {
-		 		
-                echo '[', date('Y-m-d H:i:s'), '] Running scheduled command: ', $event->getSummaryForDisplay(), PHP_EOL;
-                echo $event->buildCommand(), PHP_EOL;
-                echo '---', PHP_EOL;
-                
-                // Running pre-execution hooks and the event itself
-                $running_events[] = $event->callBeforeCallbacks(new Invoker())
-                                          ->run(new Invoker());   
-		}
-		
-        if (!count($running_events)) {		  
-			$this->outputComment('No task is due!');
-        }
-
-        // Running the post-execution hooks
-        while (count($running_events)) {
-            foreach ($running_events as $key => $event) {
-                if ($event->process->isRunning()) {
-                    continue;
-                }
-
-                $event->callAfterCallbacks(new Invoker());
-                unset($running_events[$key]);
-            }
-        }
-	}
-	
-	/**
-     * Gets the requested task
-     *
-     * @param $events  All available events
-     * @param $dueEvents  All due events
-	 * @param $requested_task The number of requested task, as it is listed using schedule:list
-     *
-     * @return array Returns the requested event, exit with error message otherwise
-     */
-	protected function getTask($events, $dueEvents, $requsted_task, $force) {
-		if (empty($events[$requsted_task - 1]))
+		if ($requsted_task !== null)
 		{
-		  $this->outputComment('The requested task does not exists.');
-		}
-		elseif (!empty($events[$requsted_task - 1]) && empty($dueEvents[$requsted_task - 1]) && !$force)
-		{
-		  $this->outputComment('The requested task exists but it is not due.');
+			return $this->getTask($events, $dueEvents, $requsted_task, $force);
 		}
 		else
 		{
-		  return [$events[$requsted_task - 1]];
+			return ($force) ? $events : $dueEvents;
 		}
-  }
-  
-	protected function outputComment($comment = '') {
-	if (isset($this->output))
-	{
-	  $this->output->writeln("<comment>$comment</comment>");
 	}
-	exit();
-  }
+
+	/**
+	 * Runs all the events
+	 *
+	 * @param $events
+	 * @return void
+	 */
+	protected function runEvents($events)
+	{
+		$running_events = [];
+		foreach ($events as $event) {
+
+			echo '[', date('Y-m-d H:i:s'), '] Running scheduled command: ', $event->getSummaryForDisplay(), PHP_EOL;
+			echo $event->buildCommand(), PHP_EOL;
+			echo '---', PHP_EOL;
+
+			// Running pre-execution hooks and the event itself
+			$running_events[] = $event->callBeforeCallbacks(new Invoker())
+					->run(new Invoker());
+		}
+
+		if (!count($running_events))
+		{
+			$this->outputComment('No task is due!');
+		}
+
+		// Running the post-execution hooks
+		while (count($running_events)) {
+			foreach ($running_events as $key => $event) {
+				if ($event->process->isRunning())
+				{
+					continue;
+				}
+
+				$event->callAfterCallbacks(new Invoker());
+				unset($running_events[$key]);
+			}
+		}
+	}
+
+	/**
+	 * Gets the requested task
+	 *
+	 * @param $events  All available events
+	 * @param $dueEvents  All due events
+	 * @param $requested_task The number of requested task, as it is listed using schedule:list
+	 *
+	 * @return array Returns the requested event, exit with error message otherwise
+	 */
+	protected function getTask($events, $dueEvents, $requsted_task, $force)
+	{
+		if (empty($events[$requsted_task - 1]))
+		{
+			$this->outputComment('The requested task does not exists.');
+		}
+		elseif (!empty($events[$requsted_task - 1]) && empty($dueEvents[$requsted_task - 1]) && !$force)
+		{
+			$this->outputComment('The requested task exists but it is not due.');
+		}
+		else
+		{
+			return [$events[$requsted_task - 1]];
+		}
+	}
+
+	protected function outputComment($comment = '')
+	{
+		if (isset($this->output))
+		{
+			$this->output->writeln("<comment>$comment</comment>");
+		}
+		exit();
+	}
 
 }

--- a/src/Console/Commands/ScheduleRunCommand.php
+++ b/src/Console/Commands/ScheduleRunCommand.php
@@ -13,219 +13,219 @@ use Crunz\Invoker;
 
 class ScheduleRunCommand extends Command
 {
-	/**
-	 * Command arguments
-	 *
-	 * @var array
-	 */
-	protected $arguments;
+    /**
+     * Command arguments
+     *
+     * @var array
+     */
+    protected $arguments;
 
-	/**
-	 * Command options
-	 *
-	 * @var array
-	 */
-	protected $options;
+    /**
+     * Command options
+     *
+     * @var array
+     */
+    protected $options;
 
-	/**
-	 * Default option values
-	 *
-	 * @var array
-	 */
-	protected $defaults = [
+    /**
+     * Default option values
+     *
+     * @var array
+     */
+    protected $defaults = [
 
-		'src' => '/tasks',
-	];
+        'src' => '/tasks',
+    ];
 
-	/**
-	 * Console Output
-	 *
-	 * @var Symfony\Component\Console\Input\OutputIterface $output
-	 */
-	protected $output;
+    /**
+     * Console Output
+     *
+     * @var Symfony\Component\Console\Input\OutputIterface $output
+     */
+    protected $output;
 
-	/**
-	 * Output Message
-	 *
-	 * @var $output_message
-	 */
-	protected $output_message;
+    /**
+     * Output Message
+     *
+     * @var $output_message
+     */
+    protected $output_message;
 
-	/**
-	 * Configures the current command
-	 *
-	 */
-	protected function configure()
-	{
-		$this->setName('schedule:run')
-				->setDescription('Start the scheduler')
-				->setDefinition([
-					new InputArgument('source', InputArgument::OPTIONAL, 'The source directory to collect the tasks.', getenv('CRUNZ_HOME') . $this->defaults['src']),
-					new InputOption('task', '-t', InputOption::VALUE_OPTIONAL, 'The task to run from the list.', null),
-					new InputOption('force', '-f', InputOption::VALUE_NONE, 'The command will run instantly.', null),
-				])
-				->setHelp('This command starts the scheduler.');
-	}
+    /**
+     * Configures the current command
+     *
+     */
+    protected function configure()
+    {
+        $this->setName('schedule:run')
+                ->setDescription('Start the scheduler')
+                ->setDefinition([
+                    new InputArgument('source', InputArgument::OPTIONAL, 'The source directory to collect the tasks.', getenv('CRUNZ_HOME') . $this->defaults['src']),
+                    new InputOption('task', '-t', InputOption::VALUE_OPTIONAL, 'The task to run from the list.', null),
+                    new InputOption('force', '-f', InputOption::VALUE_NONE, 'The command will run instantly.', null),
+                ])
+                ->setHelp('This command starts the scheduler.');
+    }
 
-	/**
-	 * Executes the current command
-	 *
-	 * @param use Symfony\Component\Console\Input\InputInterface $input
-	 * @param use Symfony\Component\Console\Input\OutputIterface $output
-	 *
-	 * @return null|int null or 0 if everything went fine, or an error code
-	 */
-	protected function execute(InputInterface $input, OutputInterface $output)
-	{
-		$this->arguments = $input->getArguments();
-		$this->options = $input->getOptions();
-		$src = $this->arguments['source'];
-		$task_files = TaskfileFinder::collectFiles($src);
-		$requested_task_number = $this->options['task'];
-		$force = (bool) $this->options['force'];
-		$this->output = $output;
+    /**
+     * Executes the current command
+     *
+     * @param use Symfony\Component\Console\Input\InputInterface $input
+     * @param use Symfony\Component\Console\Input\OutputIterface $output
+     *
+     * @return null|int null or 0 if everything went fine, or an error code
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->arguments = $input->getArguments();
+        $this->options = $input->getOptions();
+        $src = $this->arguments['source'];
+        $task_files = TaskfileFinder::collectFiles($src);
+        $requested_task_number = $this->options['task'];
+        $force = (bool) $this->options['force'];
+        $this->output = $output;
 
-		$events = $this->getEvents($task_files, $requested_task_number, $force);
-		if (!empty($events))
-		{
-			$this->runEvents($events);
-		}
-		else
-		{
-			$this->outputComment($this->output_message);
-		}
-	}
+        $events = $this->getEvents($task_files, $requested_task_number, $force);
+        if (!empty($events))
+        {
+            $this->runEvents($events);
+        }
+        else
+        {
+            $this->outputComment($this->output_message);
+        }
+    }
 
-	/**
-	 * Gets all the events
-	 *
-	 * @param $task_files
-	 * @param $requested_task_number If this is set the method only returns the requested task
-	 * @param $force If set to true, this method returns all events, if false it only returns events which are due
-	 *
-	 * @return array Returns all the events as requested
-	 */
-	protected function getEvents($task_files, $requested_task_number, $force)
-	{
-		if (!count($task_files))
-		{
-			$this->output_message = 'No task found!';
-		}
+    /**
+     * Gets all the events
+     *
+     * @param $task_files
+     * @param $requested_task_number If this is set the method only returns the requested task
+     * @param $force If set to true, this method returns all events, if false it only returns events which are due
+     *
+     * @return array Returns all the events as requested
+     */
+    protected function getEvents($task_files, $requested_task_number, $force)
+    {
+        if (!count($task_files))
+        {
+            $this->output_message = 'No task found!';
+        }
 
-		$events = array();
-		$dueEvents = array();
+        $events = array();
+        $dueEvents = array();
 
-		foreach ($task_files as $taskFile) {
+        foreach ($task_files as $taskFile) {
 
-			$schedule = require $taskFile->getRealPath();
-			if (!$schedule instanceof Schedule)
-			{
-				continue;
-			}
+            $schedule = require $taskFile->getRealPath();
+            if (!$schedule instanceof Schedule)
+            {
+                continue;
+            }
 
-			$eventsTemp = $schedule->events();
-			foreach ($eventsTemp as $event) {
-				$events[] = $event;
-			}
-			$dueEventsTemp = $schedule->dueEvents(new Invoker());
-			foreach ($dueEventsTemp as $dueEvent) {
-				$dueEvents[] = $dueEvent;
-			}
-		}
+            $eventsTemp = $schedule->events();
+            foreach ($eventsTemp as $event) {
+                $events[] = $event;
+            }
+            $dueEventsTemp = $schedule->dueEvents(new Invoker());
+            foreach ($dueEventsTemp as $dueEvent) {
+                $dueEvents[] = $dueEvent;
+            }
+        }
 
-		if ($requested_task_number !== null)
-		{
-			return $this->getTask($events, $requested_task_number, $force);
-		}
-		else
-		{
-			if (empty($events) OR (empty($dueEvents) && !$force)) 
-			{
-				$this->output_message = 'No task is due.';
-				return array();
-			}
-			return ($force) ? $events : $dueEvents;
-		}
-	}
+        if ($requested_task_number !== null)
+        {
+            return $this->getTask($events, $requested_task_number, $force);
+        }
+        else
+        {
+            if (empty($events) OR ( empty($dueEvents) && !$force))
+            {
+                $this->output_message = 'No task is due.';
+                return array();
+            }
+            return ($force) ? $events : $dueEvents;
+        }
+    }
 
-	/**
-	 * Runs all the events
-	 *
-	 * @param $events
-	 * @return void
-	 */
-	protected function runEvents($events)
-	{
-		$running_events = [];
-		foreach ($events as $event) {
-			$msg = '';
-			$msg .= '[' . date('Y-m-d H:i:s') . '] Running scheduled command: ' . $event->getSummaryForDisplay() . PHP_EOL;
-			$msg .= $event->buildCommand() . PHP_EOL;
-			$msg .= '---' . PHP_EOL;
+    /**
+     * Runs all the events
+     *
+     * @param $events
+     * @return void
+     */
+    protected function runEvents($events)
+    {
+        $running_events = [];
+        foreach ($events as $event) {
+            $msg = '';
+            $msg .= '[' . date('Y-m-d H:i:s') . '] Running scheduled command: ' . $event->getSummaryForDisplay() . PHP_EOL;
+            $msg .= $event->buildCommand() . PHP_EOL;
+            $msg .= '---' . PHP_EOL;
 
-			$this->outputComment($msg);
+            $this->outputComment($msg);
 
-			// Running pre-execution hooks and the event itself
-			$running_events[] = $event->callBeforeCallbacks(new Invoker())
-					->run(new Invoker());
-		}
+            // Running pre-execution hooks and the event itself
+            $running_events[] = $event->callBeforeCallbacks(new Invoker())
+                    ->run(new Invoker());
+        }
 
-		if (!count($running_events))
-		{
-			$this->outputComment('No task is due!');
-		}
+        if (!count($running_events))
+        {
+            $this->outputComment('No task is due!');
+        }
 
-		// Running the post-execution hooks
-		while (count($running_events)) {
-			foreach ($running_events as $key => $event) {
-				if ($event->process->isRunning())
-				{
-					continue;
-				}
+        // Running the post-execution hooks
+        while (count($running_events)) {
+            foreach ($running_events as $key => $event) {
+                if ($event->process->isRunning())
+                {
+                    continue;
+                }
 
-				$event->callAfterCallbacks(new Invoker());
-				unset($running_events[$key]);
-			}
-		}
-	}
+                $event->callAfterCallbacks(new Invoker());
+                unset($running_events[$key]);
+            }
+        }
+    }
 
-	/**
-	 * Gets the requested task
-	 *
-	 * @param $events  All available events
-	 * @param $requested_task_number The requested task, as it is defined using schedule:list
-	 * @param $force 
-	 * @return array Returns the requested event, exit with error message otherwise
-	 */
-	protected function getTask($events, $requested_task_number, $force)
-	{
-		// The schdeule:list command displays the tasks starting with 1, and the events array is 0 based, 
-		// so we need to substract 1 from the requested task number  
-		$requested_task_key = $requested_task_number - 1;
+    /**
+     * Gets the requested task
+     *
+     * @param $events  All available events
+     * @param $requested_task_number The requested task, as it is defined using schedule:list
+     * @param $force 
+     * @return array Returns the requested event, exit with error message otherwise
+     */
+    protected function getTask($events, $requested_task_number, $force)
+    {
+        // The schdeule:list command displays the tasks starting with 1, and the events array is 0 based, 
+        // so we need to substract 1 from the requested task number  
+        $requested_task_key = $requested_task_number - 1;
 
-		if (empty($events[$requested_task_key]))
-		{
-			$this->output_message = 'The requested task does not exists.';
-			return array();
-		}
-		else
-		{
-			$isTaskDue = (bool) $events[$requested_task_key]->isDue(new Invoker());
-			if (!$isTaskDue && !$force)
-			{
-				$this->outputComment('The requested task exists but it is not due.');
-				return array();
-			}
-			return [$events[$requested_task_key]];
-		}
-	}
+        if (empty($events[$requested_task_key]))
+        {
+            $this->output_message = 'The requested task does not exists.';
+            return array();
+        }
+        else
+        {
+            $isTaskDue = (bool) $events[$requested_task_key]->isDue(new Invoker());
+            if (!$isTaskDue && !$force)
+            {
+                $this->outputComment('The requested task exists but it is not due.');
+                return array();
+            }
+            return [$events[$requested_task_key]];
+        }
+    }
 
-	protected function outputComment($comment = '')
-	{
-		if (isset($this->output))
-		{
-			$this->output->writeln("<comment>$comment</comment>");
-		}
-	}
+    protected function outputComment($comment = '')
+    {
+        if (isset($this->output))
+        {
+            $this->output->writeln("<comment>$comment</comment>");
+        }
+    }
 
 }

--- a/src/Stubs/Test.php
+++ b/src/Stubs/Test.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------------------
+|  Task File
+|--------------------------------------------------------------------------------------
+|
+| This file basically registers a new task to be executed by Crunz
+| To get the list of all frequency and constraint method, you may
+| go to this link: https://github.com/lavary/crunz#scheduling-frequency-and-constraints
+|
+*/
+
+use Crunz\Schedule;
+
+
+$scheduler = new Schedule();
+
+$scheduler->run('TestCommand')
+          ->description('Test task')
+          ->in('DummyPath')
+          ->everyMinute()
+          ->sundays();
+
+
+return $scheduler;          

--- a/src/TaskfileFinder.php
+++ b/src/TaskfileFinder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Crunz;
+use Symfony\Component\Finder\Finder;
+
+class TaskfileFinder
+{
+    
+    /**
+    * Collect all task files
+    *
+    * @param  string $source
+    * @return Iterator
+    */
+    public static function collectFiles($source)
+    {    
+        if(!file_exists($source)) {
+            return [];
+        }
+        
+        $finder   = new Finder();
+        $iterator = $finder->files()
+                  ->name('*Tasks.php')
+                  ->in($source);
+        
+        return $iterator;
+    }
+
+    
+
+}

--- a/tests/ScheduleRunCommandTest.php
+++ b/tests/ScheduleRunCommandTest.php
@@ -46,7 +46,7 @@ class ScheduleRunCommandTest extends PHPUnit_Framework_TestCase
 	public function testScheduleRunCommandOutputTaskExist()
 	{
 		$dw = (int) date( "w", time());
-		$assertmsg = ($dw===0) ? "Test task" : 'No task is due';
+		$assertmsg = ($dw===0) ? "Test task" : 'The requested task exists but it is not due.';
 		$this->executeCommand(false, 1, $assertmsg);
 	}
 

--- a/tests/ScheduleRunCommandTest.php
+++ b/tests/ScheduleRunCommandTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Crunz\Console\Commands\ScheduleRunCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ScheduleRunCommandTest extends PHPUnit_Framework_TestCase
+{
+
+	public function setUp()
+	{
+		if (!file_exists(getenv('CRUNZ_HOME') . '/testtasks/'))
+		{
+			mkdir(getenv('CRUNZ_HOME') . '/testtasks/', 0744, true);
+		}
+		$stub = file_get_contents(getenv('CRUNZ_HOME') . '/src/Stubs/Test.php');
+		file_put_contents(getenv('CRUNZ_HOME') . '/testtasks/TestTasks.php', $stub);
+	}
+
+	public function tearDown()
+	{
+		unlink(getenv('CRUNZ_HOME') . '/testtasks/TestTasks.php');
+		if (file_exists(getenv('CRUNZ_HOME') . '/testtasks/'))
+		{
+			rmdir(getenv('CRUNZ_HOME') . '/testtasks/');
+		}
+	}
+	
+	public function testScheduleRunCommandOutputWithoutForceFlag()
+	{
+		$dw = (int) date( "w", time());
+		$assertmsg = ($dw===0) ? "Test task" : 'No task is due';
+		$this->executeCommand(false, false, $assertmsg);
+	}
+
+	public function testScheduleRunCommandOutputWithForceFlag()
+	{
+		$this->executeCommand(true, false, 'Test task');
+	}
+
+	public function testScheduleRunCommandOutputTaskDoesNotExist()
+	{
+		$this->executeCommand(false, 2, 'The requested task does not exists');
+	}
+	
+	public function testScheduleRunCommandOutputTaskExist()
+	{
+		$dw = (int) date( "w", time());
+		$assertmsg = ($dw===0) ? "Test task" : 'No task is due';
+		$this->executeCommand(false, 1, $assertmsg);
+	}
+
+	protected function executeCommand($force, $task, $assertmsg)
+	{
+		$application = new Application();
+		$application->add(new ScheduleRunCommand());
+		$command = $application->find('schedule:run');
+		$commandTester = new CommandTester($command);
+		$array['command'] = $command->getName();
+		$array['source'] = getenv('CRUNZ_HOME') . '/testtasks/';
+		$array['-f'] = $force;
+		
+		if ($task)
+		{
+			$array['-t'] = (int) $task;
+		}
+		$commandTester->execute($array);
+
+		$this->assertContains($assertmsg, $commandTester->getDisplay());
+	}
+
+}


### PR DESCRIPTION
This should solve issue number #11.

1, Adding the -f or --force flag to the schedule:run command force runs the task(s) immediately regardless of the timing of the task(s)

2, Adding the -t or --task flag to the schedule:run command indicates which task number from schedule:list is to be run now

So for example:
schedule:run runs all tasks which are due
schedule:run -f runs all tasks regardless of their timing
schedule:run -t1 runs task number 1 from schedule:list if it exist and it is due
schedule:run -t1 -f runs task number 1 from schedule:list if it exists regardless of the task’s timing
