### PR TITLE
Test for register_argc_argv (must be set to On)

### DIFF
--- a/crunz
+++ b/crunz
@@ -13,6 +13,14 @@
 |
 */
 
+if (!ini_get('register_argc_argv')) {
+     fwrite(STDERR,
+        'register_argc_argv must be set to On in your php.ini for crunz to work!' . PHP_EOL .
+        ' register_argc_argv=On' . PHP_EOL
+    );
+    die(1);
+}
+
 foreach ([        
          
         __DIR__ . '/../autoload.php',


### PR DESCRIPTION
Took me a while to while to work out what the problem was
My host has turned register_argc_argv=Off in the php.ini
i.e. no $_SERVER['argc'] and $_SERVER['argv']