### PR TITLE
Only mail output if there is one

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lavary/crunz",
+    "name": "kinoute/crunz",
     "description": "Schedule your tasks right from the code.",
     "type": "library",
     "keywords": [
@@ -12,7 +12,7 @@
         "Job Manager",
         "Event Runner"
     ],
-    "homepage": "https://github.com/lavary/crunz",
+    "homepage": "https://github.com/kinoute/crunz",
     "license": "MIT",
     "authors": [
         {

--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -209,7 +209,7 @@ class EventRunner {
         // Send error as email as configured
         if ($this->config('email_errors')) {
             $this->mailer->send(
-                'Crunz: reporting error for event:' . (($event->description) ? $event->description : $event->getId()),
+                'Crunz: reporting error for event: ' . (($event->description) ? $event->description : $event->getId()),
                 $this->formatEventError($event)
             );
         }

--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -184,8 +184,8 @@ class EventRunner {
             $this->display($event->getOutputStream());
         }
 
-        // Email the output
-        if ($this->config('email_output')) {
+        // Email the output if there is one
+        if ($this->config('email_output') && !empty($event->outputStream)) {
             $this->mailer->send(
                 'Crunz: output for event: ' . (($event->description) ? $event->description : $event->getId()),
                 $this->formatEventOutput($event)


### PR DESCRIPTION
Two fixes:
- Space missing
- When enabled, output should be mailed only if it's not empty