### PR TITLE
Send output by email only if it is not empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Crunz sends output email even if the output is empty,
+solves issue [#64](https://github.com/lavary/crunz/issues/64) - PR
+[#90](https://github.com/lavary/crunz/pull/90), [@PabloKowalczyk](https://github.com/PabloKowalczyk)
+
 ## 1.6.0 - 2018-04-22
 
 ### Added

--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -193,7 +193,7 @@ class EventRunner
         }
 
         // Email the output
-        if ($this->config('email_output')) {
+        if (!empty($event->getOutputStream()) && $this->config('email_output')) {
             $this->mailer->send(
                 'Crunz: output for event: ' . (($event->description) ? $event->description : $event->getId()),
                 $this->formatEventOutput($event)
@@ -236,6 +236,7 @@ class EventRunner
             . '('
             . $event->getCommandForDisplay()
             . ') '
+            . PHP_EOL
             . PHP_EOL
             . $event->outputStream
             . PHP_EOL;


### PR DESCRIPTION
Fixes https://github.com/lavary/crunz/issues/64