### PR TITLE
Added timezone option (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `timezone` option to config file - PR [#94](https://github.com/lavary/crunz/pull/94),
+[@PabloKowalczyk](https://github.com/PabloKowalczyk)
+
+### Deprecated
+- `timezone` option in config file is now required,
+lack of it will result in Exception in version `2.0`
+
 ## 1.6.1 - 2018-05-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -460,6 +460,11 @@ source: tasks
 # to make sure all the existing tasks files are renamed accordingly.
 suffix: Tasks.php
 
+# Timezone is used to calculate task run time
+# This option is very important and not setting it is deprecated
+# and will result in exception in 2.0 version.
+timezone: ~
+
 # By default the errors are not logged by Crunz
 # You may set the value to true for logging the errors
 log_errors: false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,7 @@ touch "$PHP_INI_PATH";
 
 echo "display_errors = On" >> "$PHP_INI_PATH";
 echo "display_startup_errors = On" >> "$PHP_INI_PATH";
+echo "error_reporting = E_ALL" >> "$PHP_INI_PATH";
 echo "log_errors = On" >> "$PHP_INI_PATH";
 echo "error_log = /var/log/php_error.log" >> "$PHP_INI_PATH";
 
@@ -37,7 +38,7 @@ SCRIPT
 
 $composer = <<SCRIPT
 
-COMPOSER_VERSION="1.6.4";
+COMPOSER_VERSION="1.6.5";
 BIN_DIR="/home/vagrant/bin";
 COMPOSER_FILE="$BIN_DIR/composer";
 
@@ -71,5 +72,5 @@ Vagrant.configure("2") do |config|
     end
 
     config.vm.provision "shell", inline: $script
-    config.vm.provision "shell", inline: $composer
+    config.vm.provision "shell", inline: $composer, privileged: false
 end

--- a/composer.json
+++ b/composer.json
@@ -28,18 +28,19 @@
         "php": "^5.6 || ^7.0",
         "guzzlehttp/guzzle": "^6.1",
         "jeremeamia/superclosure": "^2.2",
-        "nikic/php-parser": "^2.1.1 || ^3.0 || ^4.0",
         "monolog/monolog": "^1.19",
         "mtdowling/cron-expression": "^1.1",
         "nesbot/carbon": "^1.21",
+        "nikic/php-parser": "^2.1.1 || ^3.0 || ^4.0",
         "swiftmailer/swiftmailer": "^5.4 || ^6.0",
         "symfony/config": "^2.7 || ^3.3 || ^4.0",
         "symfony/console": "^2.7 || ^3.3 || ^4.0",
         "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",
+        "symfony/filesystem": "^2.7 || ^3.3 || ^4.0",
         "symfony/finder": "^2.7 || ^3.3 || ^4.0",
         "symfony/process": "^2.7.11 || ^3.3 || ^4.0",
-        "symfony/yaml": "^2.7 || ^3.3 || ^4.0",
-        "symfony/property-access": "^2.7 || ^3.3 || ^4.0"
+        "symfony/property-access": "^2.7 || ^3.3 || ^4.0",
+        "symfony/yaml": "^2.7 || ^3.3 || ^4.0"
     },
     "require-dev": {
         "ext-mbstring": "*",
@@ -47,7 +48,6 @@
         "phpdocumentor/reflection-docblock": "^2.0.1",
         "phpunit/phpunit": "5.7.27",
         "sebastian/comparator": "1.2.4",
-        "symfony/debug": "^3.3 || ^4.0",
         "symfony/phpunit-bridge": "^2.8 || ^3.3 || ^4.0",
         "symfony/var-dumper": "^3.4"
     },

--- a/config/services.xml
+++ b/config/services.xml
@@ -13,6 +13,7 @@
             <argument type="service" id="Crunz\Task\Collection"/>
             <argument type="service" id="Crunz\Configuration\Configuration"/>
             <argument type="service" id="Crunz\EventRunner"/>
+            <argument type="service" id="Crunz\Task\Timezone"/>
         </service>
 
         <service
@@ -27,6 +28,8 @@
             id="Crunz\Console\Command\ConfigGeneratorCommand"
             public="true"
         >
+            <argument type="service" id="Crunz\Timezone\ProviderInterface"/>
+            <argument type="service" id="Symfony\Component\Filesystem\Filesystem"/>
         </service>
 
         <service
@@ -128,6 +131,12 @@
         </service>
 
         <service
+            class="Crunz\Timezone\Provider"
+            id="Crunz\Timezone\ProviderInterface"
+            public="false"
+        />
+
+        <service
             class="Crunz\EventRunner"
             id="Crunz\EventRunner"
             public="false"
@@ -136,6 +145,20 @@
             <argument type="service" id="Crunz\Configuration\Configuration"/>
             <argument type="service" id="Crunz\Mailer"/>
             <argument type="service" id="Crunz\Logger\LoggerFactory"/>
+        </service>
+
+        <service
+            class="Symfony\Component\Filesystem\Filesystem"
+            id="Symfony\Component\Filesystem\Filesystem"
+        />
+
+        <service
+            class="Crunz\Task\Timezone"
+            id="Crunz\Task\Timezone"
+            public="false"
+        >
+            <argument type="service" id="Crunz\Configuration\Configuration"/>
+            <argument type="service" id="Crunz\Timezone\ProviderInterface"/>
         </service>
     </services>
 </container>

--- a/crunz.yml
+++ b/crunz.yml
@@ -11,13 +11,18 @@ source: tasks
 # to make sure all the existing tasks files are renamed accordingly.
 suffix: Tasks.php
 
+# Timezone is used to calculate task run time
+# This option is very important and not setting it is deprecated
+# and will result in exception in 2.0 version.
+timezone: ~
+
 # By default the errors are not logged by Crunz
 # You may set the value to true for logging the errors
 log_errors: false
 
 # This is the absolute path to the errors' log file
 # You need to make sure you have the required permission to write to this file though.
-errors_log_file:
+errors_log_file: ~
 
 # By default the output is not logged as they are redirected to the
 # null output.
@@ -27,7 +32,7 @@ log_output: false
 # This is the absolute path to the global output log file
 # The events which have dedicated log files (defined with them), won't be
 # logged to this file though.
-output_log_file:
+output_log_file: ~
 
 # By default line breaks in logs aren't allowed.
 # Set the value to true to allow them.
@@ -40,7 +45,6 @@ email_output: false
 email_errors: false
 
 # Global Swift Mailer settings
-#
 mailer:
     # Possible values: smtp, mail, and sendmail
     transport: smtp
@@ -50,10 +54,9 @@ mailer:
 
 
 # SMTP settings
-#
 smtp:
-    host:
-    port:
-    username:
-    password:
-    encryption:
+    host: ~
+    port: ~
+    username: ~
+    password: ~
+    encryption: ~

--- a/src/Configuration/Definition.php
+++ b/src/Configuration/Definition.php
@@ -26,6 +26,10 @@ class Definition implements ConfigurationInterface
                     ->info('The suffix for filenames' . PHP_EOL)
                 ->end()
 
+                ->scalarNode('timezone')
+                    ->info('Timezone used to calculate task run date')
+                ->end()
+
                 ->booleanNode('log_errors')
                     ->defaultFalse()
                     ->info('Flag for logging errors' . PHP_EOL)

--- a/src/Console/Command/Command.php
+++ b/src/Console/Command/Command.php
@@ -23,14 +23,14 @@ class Command extends BaseCommand
     /**
      * Input object.
      *
-     * @var use Symfony\Component\Console\Input\InputInterface
+     * @var \Symfony\Component\Console\Input\InputInterface
      */
     protected $input;
 
     /**
      * output object.
      *
-     * @var use Symfony\Component\Console\Input\OutputInterface
+     * @var \Symfony\Component\Console\Output\OutputInterface
      */
     protected $output;
 }

--- a/src/Console/Command/ConfigGeneratorCommand.php
+++ b/src/Console/Command/ConfigGeneratorCommand.php
@@ -2,45 +2,133 @@
 
 namespace Crunz\Console\Command;
 
+use Crunz\Output\VerbosityAwareOutput;
+use Crunz\Timezone\ProviderInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ConfigGeneratorCommand extends Command
 {
+    /** @var ProviderInterface */
+    private $timezoneProvider;
+    /** @var Filesystem */
+    private $filesystem;
+
+    public function __construct(ProviderInterface $timezoneProvider, Filesystem $filesystem)
+    {
+        $this->timezoneProvider = $timezoneProvider;
+        $this->filesystem = $filesystem;
+
+        parent::__construct();
+    }
+
     /**
      * Configures the current command.
      */
     protected function configure()
     {
-        $this->setName('publish:config')
-            ->setDescription('Generates a config file within the project\'s root directory.')
-            ->setHelp('This generates a config file in YML format within the project\'s root directory.');
+        $this
+            ->setName('publish:config')
+            ->setDescription("Generates a config file within the project's root directory.")
+            ->setHelp("This generates a config file in YML format within the project's root directory.")
+        ;
     }
 
     /**
-     * Executes the current command.
-     *
-     * @param use Symfony\Component\Console\Input\InputInterface $input
-     * @param use Symfony\Component\Console\Input\OutputIterface $output
-     *
-     * @return null|int null or 0 if everything went fine, or an error code
+     * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $filename = getbase() . '/crunz.yml';
+        $verbosityAwareOutput = new VerbosityAwareOutput($output);
+        $symfonyStyleIo = new SymfonyStyle($input, $output);
 
-        if (file_exists($filename)) {
-            $output->writeln('<comment>The configuration file already exists.</comment>');
-            exit();
+        $path = getbase() . '/crunz.yml';
+        $destination = \realpath($path) ?: $path;
+        $configExists = $this->filesystem
+            ->exists($destination)
+        ;
+
+        $verbosityAwareOutput->writeln(
+            "<info>Destination config file: '{$destination}'.</info>",
+            OutputInterface::VERBOSITY_VERBOSE
+        );
+
+        if ($configExists) {
+            $verbosityAwareOutput->writeln(
+                "<comment>The configuration file already exists at '{$destination}'.</comment>"
+            );
+
+            return 0;
         }
 
         $src = __DIR__ . '/../../../crunz.yml';
-        if (copy($src, $filename)) {
-            $output->writeln('<info>The configuration file was generated successfully.</info>');
-            exit();
-        }
+        $verbosityAwareOutput->writeln(
+            "<info>Source config file: '{$src}'.</info>",
+            OutputInterface::VERBOSITY_VERBOSE
+        );
+        $defaultTimezone = $this->askForTimezone($symfonyStyleIo);
+        $verbosityAwareOutput->writeln(
+            "<info>Provided timezone: '{$defaultTimezone}'.</info>",
+            OutputInterface::VERBOSITY_VERBOSE
+        );
 
-        $output->writeln('<comment>There was a problem when generating the file.</comment>');
-        exit();
+        $this->updateTimezone(
+            $destination,
+            $src,
+            $defaultTimezone
+        );
+
+        $output->writeln('<info>The configuration file was generated successfully.</info>');
+
+        return 0;
+    }
+
+    /**
+     * @return string
+     */
+    protected function askForTimezone(SymfonyStyle $symfonyStyleIo)
+    {
+        $defaultTimezone = $this->timezoneProvider
+            ->defaultTimezone()
+            ->getName()
+        ;
+        $question = new Question(
+            '<question>Please provide default timezone for task run date calculations</question>',
+            $defaultTimezone
+        );
+        $question->setAutocompleterValues(\DateTimeZone::listIdentifiers());
+        $question->setValidator(
+            function ($answer) {
+                try {
+                    new \DateTimeZone($answer);
+                } catch (\Exception $exception) {
+                    throw new \Exception("Timezone '{$answer}' is not valid. Please provide valid timezone.");
+                }
+
+                return $answer;
+            }
+        );
+
+        return $symfonyStyleIo->askQuestion($question);
+    }
+
+    private function updateTimezone(
+        $destination,
+        $src,
+        $timezone
+    ) {
+        $this->filesystem
+            ->dumpFile(
+                $destination,
+                \str_replace(
+                    'timezone: ~',
+                    "timezone: {$timezone}",
+                    \file_get_contents($src)
+                )
+            )
+        ;
     }
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Closure;
 use Cron\CronExpression;
 use Crunz\Exception\NotImplementedException;
+use Crunz\Logger\Logger;
 use GuzzleHttp\Client as HttpClient;
 use SuperClosure\Serializer;
 use Symfony\Component\Process\Process;
@@ -56,7 +57,7 @@ class Event
     /**
      * Event personal logger instance.
      *
-     * @var string
+     * @var Logger
      */
     public $logger;
     /**
@@ -255,9 +256,9 @@ class Event
      *
      * @return bool
      */
-    public function isDue()
+    public function isDue(\DateTimeZone $timeZone)
     {
-        return $this->expressionPasses() && $this->filtersPass();
+        return $this->expressionPasses($timeZone) && $this->filtersPass();
     }
 
     /**
@@ -1102,9 +1103,10 @@ class Event
      *
      * @return bool
      */
-    protected function expressionPasses()
+    protected function expressionPasses(\DateTimeZone $timeZone)
     {
         $date = Carbon::now();
+        $date->setTimezone($timeZone);
 
         if ($this->timezone) {
             $date->setTimezone($this->timezone);

--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -11,7 +11,7 @@ class EventRunner
     /**
      * Schedule objects.
      *
-     * @var array
+     * @var Schedule[]
      */
     protected $schedules = [];
     /**

--- a/src/Output/VerbosityAwareOutput.php
+++ b/src/Output/VerbosityAwareOutput.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Crunz\Output;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @TODO Remove it in Crunz v2.
+ */
+class VerbosityAwareOutput
+{
+    /** @var OutputInterface */
+    private $output;
+
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    public function write($messages, $verbosity = OutputInterface::VERBOSITY_NORMAL)
+    {
+        $commandVerbosity = $this->output
+            ->getVerbosity()
+        ;
+
+        if ($commandVerbosity >= $verbosity) {
+            $this->output
+                ->write($messages)
+            ;
+        }
+    }
+
+    public function writeln($messages, $verbosity = OutputInterface::VERBOSITY_NORMAL)
+    {
+        $commandVerbosity = $this->output
+            ->getVerbosity()
+        ;
+
+        if ($commandVerbosity >= $verbosity) {
+            $this->output
+                ->writeln($messages)
+            ;
+        }
+    }
+}

--- a/src/Schedule.php
+++ b/src/Schedule.php
@@ -172,7 +172,7 @@ class Schedule
      */
     public function events(array $events = null)
     {
-        if (!is_null($events)) {
+        if ($events !== null) {
             return $this->events = $events;
         }
 
@@ -184,11 +184,14 @@ class Schedule
      *
      * @return array
      */
-    public function dueEvents()
+    public function dueEvents(\DateTimeZone $timeZone)
     {
-        return array_filter($this->events, function ($event) {
-            return $event->isDue();
-        });
+        return \array_filter(
+            $this->events,
+            function (Event $event) use ($timeZone) {
+                return $event->isDue($timeZone);
+            }
+        );
     }
 
     /**
@@ -213,8 +216,8 @@ class Schedule
     protected function id()
     {
         while (true) {
-            $id = uniqid();
-            if (!array_key_exists($id, $this->events)) {
+            $id = \uniqid('crunz', true);
+            if (!\array_key_exists($id, $this->events)) {
                 return $id;
             }
         }
@@ -229,8 +232,15 @@ class Schedule
      */
     protected function compileParameters(array $parameters)
     {
-        return implode(' ', array_map(function ($value, $key) {
-            return is_numeric($key) ? $value : $key . '=' . (is_numeric($value) ? $value : ProcessUtils::escapeArgument($value));
-        }, $parameters, array_keys($parameters)));
+        return implode(
+            ' ',
+            \array_map(
+                function ($value, $key) {
+                    return \is_numeric($key) ? $value : "{$key}=" . (\is_numeric($value) ? $value : ProcessUtils::escapeArgument($value));
+                },
+                $parameters,
+                \array_keys($parameters)
+            )
+        );
     }
 }

--- a/src/Task/Timezone.php
+++ b/src/Task/Timezone.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Crunz\Task;
+
+use Crunz\Configuration\Configuration;
+use Crunz\Timezone\ProviderInterface;
+
+final class Timezone
+{
+    /** @var Configuration */
+    private $configuration;
+    /** @var ProviderInterface */
+    private $timezoneProvider;
+
+    public function __construct(Configuration $configuration, ProviderInterface $timezoneProvider)
+    {
+        $this->configuration = $configuration;
+        $this->timezoneProvider = $timezoneProvider;
+    }
+
+    public function timezoneForComparisons()
+    {
+        $newTimezone = $this->configuration
+            ->get('timezone')
+        ;
+
+        /* @TODO Throw Exception in Crunz v2. */
+        if (empty($newTimezone)) {
+            @trigger_error(
+                'Timezone is not configured and this is deprecated from 1.7 and will result in exception in 2.0 version. Add `timezone` key to your YAML config file.',
+                E_USER_DEPRECATED
+            );
+
+            $newTimezone = $this->timezoneProvider
+                ->defaultTimezone()
+                ->getName()
+            ;
+        }
+
+        return new \DateTimeZone($newTimezone);
+    }
+}

--- a/src/Timezone/Provider.php
+++ b/src/Timezone/Provider.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Crunz\Timezone;
+
+final class Provider implements ProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function defaultTimezone()
+    {
+        return new \DateTimeZone(\date_default_timezone_get());
+    }
+}

--- a/src/Timezone/ProviderInterface.php
+++ b/src/Timezone/ProviderInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Crunz\Timezone;
+
+interface ProviderInterface
+{
+    /**
+     * @return \DateTimeZone
+     */
+    public function defaultTimezone();
+}

--- a/tests/Functional/ConfigProviderTest.php
+++ b/tests/Functional/ConfigProviderTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Crunz\Tests\Functional;
+
+use Crunz\Application;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ConfigProviderTest extends TestCase
+{
+    /** @test */
+    public function configAlreadyExists()
+    {
+        $application = new Application('Crunz', '0.1.0-test.1');
+        $command = $application->get('publish:config');
+
+        $commandTester = new CommandTester($command);
+        $returnCode = $commandTester->execute([]);
+
+        $this->assertSame(0, $returnCode);
+        $this->assertContains('The configuration file already exists at', $commandTester->getDisplay());
+    }
+}

--- a/tests/Unit/Timezone/ProviderTest.php
+++ b/tests/Unit/Timezone/ProviderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Crunz\Tests\Unit\Timezone;
+
+use Crunz\Timezone\Provider;
+use PHPUnit\Framework\TestCase;
+
+class ProviderTest extends TestCase
+{
+    /**
+     * @runInSeparateProcess
+     * @test
+     */
+    public function defaultTimezoneIsReturned()
+    {
+        $timezoneName = 'Europe/Warsaw';
+        \date_default_timezone_set($timezoneName);
+
+        $provider = new Provider();
+        $timezone = $provider->defaultTimezone();
+
+        $this->assertSame($timezoneName, $timezone->getName());
+    }
+}

--- a/tests/crunz.yml
+++ b/tests/crunz.yml
@@ -1,0 +1,22 @@
+source: tasks
+suffix: Tasks.php
+timezone: UTC
+log_errors: false
+errors_log_file: ~
+log_output: false
+output_log_file: ~
+log_allow_line_breaks: false
+email_output: false
+email_errors: false
+mailer:
+    transport: smtp
+    recipients:
+    sender_name:
+    sender_email:
+
+smtp:
+    host: ~
+    port: ~
+    username: ~
+    password: ~
+    encryption: ~


### PR DESCRIPTION
* Added timezone option.

* Do not require symfony/debug it is not in use.

* Report all error in CLI.

* Fix type hints.

* Type hint improved.

* Added configuration to tests env.

* Added null values.

* Added timezone provider.

* Added tasks timezone.

* Require symfony/filesystem.

* Add composer as a non-privileged user.

* Added VerbosityAwareOutput.

* Added TODO.

* Improved type hint.

* Added deprecation handler.

* Make calculation task's run date aware of timezone.

* Ask about timezone while generating config file.

* Updated changelog.