### PR TITLE
fixed compatibility with Symfony 4.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,22 +33,22 @@
         "nesbot/carbon": "^1.21",
         "nikic/php-parser": "^3.0 || ^4.0",
         "swiftmailer/swiftmailer": "^6.0",
-        "symfony/config": "^3.4 || ^4.1",
-        "symfony/console": "^3.4 || ^4.1",
-        "symfony/dependency-injection": "^3.4 || ^4.1",
-        "symfony/filesystem": "^3.4 || ^4.1",
-        "symfony/finder": "^3.4 || ^4.1",
-        "symfony/process": "^3.4 || ^4.1",
-        "symfony/property-access": "^3.4 || ^4.1",
-        "symfony/yaml": "^3.4 || ^4.1"
+        "symfony/config": "^3.4 || ^4.0",
+        "symfony/console": "^3.4 || ^4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0",
+        "symfony/filesystem": "^3.4 || ^4.0",
+        "symfony/finder": "^3.4 || ^4.0",
+        "symfony/process": "^3.4 || ^4.0",
+        "symfony/property-access": "^3.4 || ^4.0",
+        "symfony/yaml": "^3.4 || ^4.0"
     },
     "require-dev": {
         "ext-mbstring": "*",
         "friendsofphp/php-cs-fixer": "2.11.1",
         "phpdocumentor/reflection-docblock": "^2.0.1",
         "phpunit/phpunit": "7.1.5",
-        "symfony/phpunit-bridge": "^3.4.5 || ^4.1",
-        "symfony/var-dumper": "^3.4 || ^4.1"
+        "symfony/phpunit-bridge": "^3.4.5 || ^4.0",
+        "symfony/var-dumper": "^3.4 || ^4.0"
     },
     "replace": {
         "symfony/polyfill-php56": "*",


### PR DESCRIPTION
Current requirement of symfony libs, `3.4 || 4.1`, allows installing only versions that are >=3.4.0, <4.0.0, and >= 4.1.0, which precisely excludes everything 4.0.* — I think this was not intended.