### PR TITLE
Do not require cURL extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ by [@PabloKowalczyk](https://github.com/PabloKowalczyk)
 ### Removed
 
 - Remove `guzzlehttp/guzzle` dependency and use in-house `CurlHttpClient` -
-PR [#132](https://github.com/lavary/crunz/pull/136)
+PR [#136](https://github.com/lavary/crunz/pull/136)
 by [@PabloKowalczyk](https://github.com/PabloKowalczyk)
 
 ## 1.9.0 - 2018-08-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Incompatibility for users without cURL extension but with enabled `allow_url_fopen` - PR [#139](https://github.com/lavary/crunz/pull/139)
+by [@PabloKowalczyk](https://github.com/PabloKowalczyk)
+
 ## 1.10.0 - 2018-09-22
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "ext-curl": "*",
         "jeremeamia/superclosure": "^2.2",
         "monolog/monolog": "^1.19",
         "mtdowling/cron-expression": "^1.1",

--- a/config/services.xml
+++ b/config/services.xml
@@ -198,8 +198,31 @@
         </service>
 
         <service
+            class="Crunz\HttpClient\StreamHttpClient"
+            id="Crunz\HttpClient\StreamHttpClient"
+            public="false"
+        />
+
+        <service
+            class="Crunz\HttpClient\FallbackHttpClient"
+            id="Crunz\HttpClient\FallbackHttpClient"
+            public="false"
+        >
+            <argument id="Crunz\HttpClient\StreamHttpClient" type="service"/>
+            <argument id="Crunz\HttpClient\CurlHttpClient" type="service"/>
+            <argument type="service" id="Crunz\Logger\ConsoleLoggerInterface"/>
+        </service>
+
+        <service
             class="Crunz\HttpClient\CurlHttpClient"
+            id="Crunz\HttpClient\CurlHttpClient"
+            public="false"
+        />
+
+        <service
+            alias="Crunz\HttpClient\FallbackHttpClient"
             id="Crunz\HttpClient\HttpClientInterface"
+            public="false"
         />
 
         <service

--- a/src/HttpClient/FallbackHttpClient.php
+++ b/src/HttpClient/FallbackHttpClient.php
@@ -38,6 +38,7 @@ final class FallbackHttpClient implements HttpClientInterface
 
     /**
      * @return HttpClientInterface
+     *
      * @throws HttpClientException
      */
     private function chooseHttpClient()
@@ -58,7 +59,7 @@ final class FallbackHttpClient implements HttpClientInterface
             return $this->httpClient;
         }
 
-        if (\ini_get('allow_url_fopen') === '1') {
+        if ('1' === \ini_get('allow_url_fopen')) {
             $this->httpClient = $this->streamHttpClient;
 
             $this->consoleLogger

--- a/src/HttpClient/FallbackHttpClient.php
+++ b/src/HttpClient/FallbackHttpClient.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Crunz\HttpClient;
+
+use Crunz\Logger\ConsoleLoggerInterface;
+
+final class FallbackHttpClient implements HttpClientInterface
+{
+    /** @var StreamHttpClient */
+    private $streamHttpClient;
+    /** @var CurlHttpClient */
+    private $curlHttpClient;
+    /** @var HttpClientInterface|null */
+    private $httpClient;
+    /** @var ConsoleLoggerInterface */
+    private $consoleLogger;
+
+    public function __construct(
+        StreamHttpClient $streamHttpClient,
+        CurlHttpClient $curlHttpClient,
+        ConsoleLoggerInterface $consoleLogger
+    ) {
+        $this->streamHttpClient = $streamHttpClient;
+        $this->curlHttpClient = $curlHttpClient;
+        $this->consoleLogger = $consoleLogger;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @throws HttpClientException
+     */
+    public function ping($url)
+    {
+        $httpClient = $this->chooseHttpClient();
+        $httpClient->ping($url);
+    }
+
+    /**
+     * @return HttpClientInterface
+     * @throws HttpClientException
+     */
+    private function chooseHttpClient()
+    {
+        if (null !== $this->httpClient) {
+            return $this->httpClient;
+        }
+
+        $this->consoleLogger
+            ->debug('Choosing HttpClient implementation.');
+
+        if (\function_exists('curl_exec')) {
+            $this->httpClient = $this->curlHttpClient;
+
+            $this->consoleLogger
+                ->debug('cURL available, use <info>CurlHttpClient</info>.');
+
+            return $this->httpClient;
+        }
+
+        if (\ini_get('allow_url_fopen') === '1') {
+            $this->httpClient = $this->streamHttpClient;
+
+            $this->consoleLogger
+                ->debug("'allow_url_fopen' enabled, use <info>StreamHttpClient</info>");
+
+            return $this->httpClient;
+        }
+
+        $this->consoleLogger
+            ->debug('<error>Choosing HttpClient implementation failed.</error>');
+
+        throw new HttpClientException(
+            "Unable to choose HttpClient. Enable cURL extension (preffered) or turn on 'allow_url_fopen' in php.ini."
+        );
+    }
+}

--- a/src/HttpClient/StreamHttpClient.php
+++ b/src/HttpClient/StreamHttpClient.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Crunz\HttpClient;
+
+final class StreamHttpClient implements HttpClientInterface
+{
+    /**
+     * @param string $url
+     *
+     * @throws HttpClientException
+     */
+    public function ping($url)
+    {
+        $context = \stream_context_create(
+            [
+                'http' => [
+                    'user_agent' => 'Crunz StreamHttpClient',
+                    'timeout' => 5,
+                ],
+            ]
+        );
+        $resource = @\fopen(
+            $url,
+            'rb',
+            false,
+            $context
+        );
+
+        if (false === $resource) {
+            $error = \error_get_last();
+            $errorMessage = isset($error['message']) ? $error['message'] : 'Unknown error';
+
+            throw new HttpClientException("Ping failed with message: \"{$errorMessage}\".");
+        }
+
+        if ($resource) {
+            \fclose($resource);
+        }
+    }
+}

--- a/tests/Unit/HttpClient/StreamHttpClientTest.php
+++ b/tests/Unit/HttpClient/StreamHttpClientTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Crunz\Tests\Unit\HttpClient;
+
+use Crunz\HttpClient\HttpClientException;
+use Crunz\HttpClient\StreamHttpClient;
+use PHPUnit\Framework\TestCase;
+
+final class StreamHttpClientTest extends TestCase
+{
+    /** @test */
+    public function pingFailWithInvalidAddress()
+    {
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage(
+            'Ping failed with message: "fopen(http://www.wrong-address.tld): failed to open stream: php_network_getaddresses: getaddrinfo failed: Name or service not known".'
+        );
+
+        $client = new StreamHttpClient();
+        $client->ping('http://www.wrong-address.tld');
+    }
+}

--- a/tests/Unit/HttpClient/StreamHttpClientTest.php
+++ b/tests/Unit/HttpClient/StreamHttpClientTest.php
@@ -13,7 +13,7 @@ final class StreamHttpClientTest extends TestCase
     {
         $this->expectException(HttpClientException::class);
         $this->expectExceptionMessage(
-            'Ping failed with message: "fopen(http://www.wrong-address.tld): failed to open stream: php_network_getaddresses: getaddrinfo failed: Name or service not known".'
+            'Ping failed with message: "fopen(http://www.wrong-address.tld): failed to open stream: php_network_getaddresses: getaddrinfo failed:'
         );
 
         $client = new StreamHttpClient();


### PR DESCRIPTION
`ext-curl` is no longer required so users without this extension can install newest version of Crunz, also there is fallback to `StreamHttpClient` (requires `allow_url_fopen` turned on) in case user want to `ping` but do not have `ext-curl` installed/enabled.