### PR TITLE
Remove symfony\property-access dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
         "symfony/filesystem": "^2.7 || ^3.3 || ^4.0",
         "symfony/finder": "^2.7 || ^3.3 || ^4.0",
         "symfony/process": "^2.7.11 || ^3.3 || ^4.0",
-        "symfony/property-access": "^2.7 || ^3.3 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.3 || ^4.0"
     },
     "require-dev": {

--- a/config/services.php
+++ b/config/services.php
@@ -38,8 +38,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\PropertyAccess\PropertyAccessor;
-use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Yaml\Yaml;
 
 $simpleServices = [
@@ -123,21 +121,10 @@ $container
     )
 ;
 $container
-    ->register(PropertyAccessorInterface::class, PropertyAccessor::class)
-    ->setPublic(false)
-    ->setArguments(
-        [
-            false,
-            true,
-        ]
-    )
-;
-$container
     ->register(Configuration::class, Configuration::class)
     ->setPublic(false)
     ->setArguments(
         [
-            new Reference(PropertyAccessorInterface::class),
             new Reference(ConfigurationParserInterface::class),
             new Reference(FilesystemInterface::class),
         ]

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -3,26 +3,18 @@
 namespace Crunz\Configuration;
 
 use Crunz\Filesystem\FilesystemInterface;
-use Symfony\Component\PropertyAccess\Exception\AccessException;
-use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 class Configuration
 {
     /** @var array */
     private $config;
-    /** @var PropertyAccessorInterface */
-    private $propertyAccessor;
     /** @var ConfigurationParser */
     private $configurationParser;
     /** @var FilesystemInterface */
     private $filesystem;
 
-    public function __construct(
-        PropertyAccessorInterface $propertyAccessor,
-        ConfigurationParserInterface $configurationParser,
-        FilesystemInterface $filesystem
-    ) {
-        $this->propertyAccessor = $propertyAccessor;
+    public function __construct(ConfigurationParserInterface $configurationParser, FilesystemInterface $filesystem)
+    {
         $this->configurationParser = $configurationParser;
         $this->filesystem = $filesystem;
     }
@@ -46,26 +38,18 @@ class Configuration
             return $this->config[$key];
         }
 
-        $path = \implode(
-            '',
-            \array_map(
-                function ($keyPart) {
-                    return "[{$keyPart}]";
-                },
-                \explode('.', $key)
-            )
-        );
+        $parts = \explode('.', $key);
 
-        try {
-            return $this->propertyAccessor
-                ->getValue(
-                    $this->config,
-                    $path
-                )
-            ;
-        } catch (AccessException $exception) {
-            return $default;
+        $value = $this->config;
+        foreach ($parts as $part) {
+            if (!\is_array($value) || !\array_key_exists($part, $value)) {
+                return $default;
+            }
+
+            $value = $value[$part];
         }
+
+        return $value;
     }
 
     /** @return string */

--- a/tests/Unit/Configuration/ConfigurationTest.php
+++ b/tests/Unit/Configuration/ConfigurationTest.php
@@ -6,7 +6,6 @@ use Crunz\Configuration\Configuration;
 use Crunz\Configuration\ConfigurationParserInterface;
 use Crunz\Filesystem\FilesystemInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 final class ConfigurationTest extends TestCase
 {
@@ -43,7 +42,6 @@ final class ConfigurationTest extends TestCase
         ;
 
         return new Configuration(
-            new PropertyAccessor(false, true),
             $mockConfigurationParser,
             $this->createMock(FilesystemInterface::class)
         );


### PR DESCRIPTION
There is no need to install this dependency as it was used only in one place, in easy to replace with native code context.