### PR TITLE
Remove symfony\finder dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
         "symfony/console": "^2.7 || ^3.3 || ^4.0",
         "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",
         "symfony/filesystem": "^2.7 || ^3.3 || ^4.0",
-        "symfony/finder": "^2.7 || ^3.3 || ^4.0",
         "symfony/process": "^2.7.11 || ^3.3 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.3 || ^4.0"
     },

--- a/config/services.php
+++ b/config/services.php
@@ -13,6 +13,8 @@ use Crunz\Console\Command\TaskGeneratorCommand;
 use Crunz\EventRunner;
 use Crunz\Filesystem\Filesystem as CrunzFilesystem;
 use Crunz\Filesystem\FilesystemInterface;
+use Crunz\Finder\Finder;
+use Crunz\Finder\FinderInterface;
 use Crunz\HttpClient\CurlHttpClient;
 use Crunz\HttpClient\FallbackHttpClient;
 use Crunz\HttpClient\HttpClientInterface;
@@ -37,12 +39,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
 $simpleServices = [
     Definition::class,
-    Finder::class,
     Yaml::class,
     Processor::class,
     Invoker::class,
@@ -52,6 +52,7 @@ $simpleServices = [
     StreamHttpClient::class,
     CurlHttpClient::class,
     FilesystemInterface::class => CrunzFilesystem::class,
+    FinderInterface::class => Finder::class,
 ];
 
 $container
@@ -107,7 +108,7 @@ $container
     ->setArguments(
         [
             new Reference(Configuration::class),
-            new Reference(Finder::class),
+            new Reference(FinderInterface::class),
         ]
     )
 ;

--- a/src/Application.php
+++ b/src/Application.php
@@ -2,6 +2,7 @@
 
 namespace Crunz;
 
+use Crunz\Path\Path;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Application as SymfonyApplication;
@@ -90,16 +91,13 @@ class Application extends SymfonyApplication
         if ($containerCacheDirWritable) {
             $class = 'CrunzContainer';
             $baseClass = 'Container';
-            $cache = new ConfigCache(
-                implode(
-                    DIRECTORY_SEPARATOR,
-                    [
-                        $this->getContainerCacheDir(),
-                        "{$class}.php",
-                    ]
-                ),
-                true
+            $cachePath = Path::create(
+                [
+                    $this->getContainerCacheDir(),
+                    "{$class}.php",
+                ]
             );
+            $cache = new ConfigCache($cachePath->toString(), true);
 
             if (!$cache->isFresh()) {
                 $containerBuilder = $this->buildContainer();
@@ -134,9 +132,7 @@ class Application extends SymfonyApplication
     private function buildContainer()
     {
         $containerBuilder = new ContainerBuilder();
-
-        $configDir = \implode(
-            DIRECTORY_SEPARATOR,
+        $configDir = Path::create(
             [
                 __DIR__,
                 '..',
@@ -144,7 +140,7 @@ class Application extends SymfonyApplication
             ]
         );
 
-        $phpLoader = new PhpFileLoader($containerBuilder, new FileLocator($configDir));
+        $phpLoader = new PhpFileLoader($containerBuilder, new FileLocator($configDir->toString()));
         $phpLoader->load('services.php');
 
         return $containerBuilder;
@@ -197,13 +193,14 @@ class Application extends SymfonyApplication
      */
     private function getBaseCacheDir()
     {
-        return implode(
-            DIRECTORY_SEPARATOR,
+        $baseCacheDir = Path::create(
             [
                 \sys_get_temp_dir(),
                 '.crunz',
             ]
         );
+
+        return $baseCacheDir->toString();
     }
 
     /**
@@ -211,14 +208,15 @@ class Application extends SymfonyApplication
      */
     private function getContainerCacheDir()
     {
-        return implode(
-            DIRECTORY_SEPARATOR,
+        $containerCacheDir = Path::create(
             [
                 $this->getBaseCacheDir(),
                 \get_current_user(),
                 $this->getVersion(),
             ]
         );
+
+        return $containerCacheDir->toString();
     }
 
     private function registerDeprecationHandler()

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -3,6 +3,7 @@
 namespace Crunz\Configuration;
 
 use Crunz\Filesystem\FilesystemInterface;
+use Crunz\Path\Path;
 
 class Configuration
 {
@@ -55,17 +56,14 @@ class Configuration
     /** @return string */
     public function getSourcePath()
     {
-        return $this->makePath(
+        $sourcePath = Path::create(
             [
                 $this->filesystem
                     ->getCwd(),
                 $this->get('source'),
             ]
         );
-    }
 
-    private function makePath(array $parts)
-    {
-        return \implode(DIRECTORY_SEPARATOR, $parts);
+        return $sourcePath->toString();
     }
 }

--- a/src/Console/Command/ConfigGeneratorCommand.php
+++ b/src/Console/Command/ConfigGeneratorCommand.php
@@ -4,6 +4,7 @@ namespace Crunz\Console\Command;
 
 use Crunz\Filesystem\FilesystemInterface;
 use Crunz\Output\VerbosityAwareOutput;
+use Crunz\Path\Path;
 use Crunz\Timezone\ProviderInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -53,7 +54,7 @@ class ConfigGeneratorCommand extends Command
         $symfonyStyleIo = new SymfonyStyle($input, $output);
         $cwd = $this->filesystem
             ->getCwd();
-        $path = $cwd . DIRECTORY_SEPARATOR . 'crunz.yml';
+        $path = Path::create([$cwd, 'crunz.yml'])->toString();
         $destination = \realpath($path) ?: $path;
         $configExists = $this->filesystem
             ->fileExists($destination)

--- a/src/Console/Command/ScheduleListCommand.php
+++ b/src/Console/Command/ScheduleListCommand.php
@@ -79,7 +79,7 @@ class ScheduleListCommand extends Command
         );
         $row = 0;
 
-        foreach ($tasks as $key => $taskFile) {
+        foreach ($tasks as $taskFile) {
             $schedule = require $taskFile->getRealPath();
             if (!$schedule instanceof Schedule) {
                 continue;

--- a/src/Console/Command/TaskGeneratorCommand.php
+++ b/src/Console/Command/TaskGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace Crunz\Console\Command;
 
 use Crunz\Configuration\Configuration;
+use Crunz\Path\Path;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -143,7 +144,9 @@ class TaskGeneratorCommand extends Command
      */
     protected function save()
     {
-        return \file_put_contents($this->outputPath() . DIRECTORY_SEPARATOR . $this->outputFile(), $this->stub);
+        $filename = Path::create([$this->outputPath(), $this->outputFile()]);
+
+        return \file_put_contents($filename->toString(), $this->stub);
     }
 
     /**

--- a/src/Event.php
+++ b/src/Event.php
@@ -7,6 +7,7 @@ use Closure;
 use Cron\CronExpression;
 use Crunz\Exception\NotImplementedException;
 use Crunz\Logger\Logger;
+use Crunz\Path\Path;
 use Crunz\Pinger\PingableInterface;
 use Crunz\Pinger\PingableTrait;
 use SuperClosure\Serializer;
@@ -1083,9 +1084,9 @@ class Event implements PingableInterface
     {
         $closure = (new Serializer())->serialize($closure);
         $serializedClosure = \http_build_query([$closure]);
-        $crunzRoot = \getcwd() . DIRECTORY_SEPARATOR;
+        $crunzRoot = Path::create([\getcwd(), 'crunz']);
 
-        return PHP_BINARY . " {$crunzRoot}crunz closure:run {$serializedClosure}";
+        return PHP_BINARY . " {$crunzRoot->toString()} closure:run {$serializedClosure}";
     }
 
     /**

--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Crunz\Finder;
+
+use Crunz\Path\Path;
+
+final class Finder implements FinderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function find(Path $path)
+    {
+        return new \GlobIterator(
+            $path->toString(),
+            \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::SKIP_DOTS
+        );
+    }
+}

--- a/src/Finder/FinderInterface.php
+++ b/src/Finder/FinderInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Crunz\Finder;
+
+use Crunz\Path\Path;
+
+interface FinderInterface
+{
+    /** @return \SplFileInfo[] */
+    public function find(Path $path);
+}

--- a/src/Path/Path.php
+++ b/src/Path/Path.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Crunz\Path;
+
+use Crunz\Exception\CrunzException;
+
+final class Path
+{
+    private $path;
+
+    private function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * @return Path
+     *
+     * @throws CrunzException
+     */
+    public static function create(array $parts)
+    {
+        if (0 === \count($parts)) {
+            throw new CrunzException('At least one part expected.');
+        }
+
+        return new self(
+            \implode(
+                DIRECTORY_SEPARATOR,
+                $parts
+            )
+        );
+    }
+
+    public function toString()
+    {
+        return $this->path;
+    }
+}

--- a/src/Task/Collection.php
+++ b/src/Task/Collection.php
@@ -3,17 +3,17 @@
 namespace Crunz\Task;
 
 use Crunz\Configuration\Configuration;
-use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\SplFileInfo;
+use Crunz\Finder\FinderInterface;
+use Crunz\Path\Path;
 
 class Collection
 {
     /** @var Configuration */
     private $configuration;
-    /** @var Finder */
+    /** @var FinderInterface */
     private $finder;
 
-    public function __construct(Configuration $configuration, Finder $finder)
+    public function __construct(Configuration $configuration, FinderInterface $finder)
     {
         $this->configuration = $configuration;
         $this->finder = $finder;
@@ -22,7 +22,7 @@ class Collection
     /**
      * @param string $source
      *
-     * @return SplFileInfo[]|Finder
+     * @return \SplFileInfo[]
      */
     public function all($source)
     {
@@ -33,14 +33,15 @@ class Collection
         $suffix = $this->configuration
             ->get('suffix')
         ;
+        $sourcePath = Path::create(
+            [
+                $source,
+                "*{$suffix}",
+            ]
+        );
 
-        $iterator = $this->finder
-            ->files()
-            ->name("*{$suffix}")
-            ->sortByName()
-            ->in($source)
+        return $this->finder
+            ->find($sourcePath)
         ;
-
-        return $iterator;
     }
 }

--- a/tests/Functional/TaskGeneratorTest.php
+++ b/tests/Functional/TaskGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Crunz\Tests\Functional;
 
 use Crunz\Application;
+use Crunz\Path\Path;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -22,13 +23,13 @@ class TaskGeneratorTest extends TestCase
 
         $this->outputDirectory = \sys_get_temp_dir();
         $this->fileName = 'CrunzTest';
-        $this->taskFilePath = \implode(
-            DIRECTORY_SEPARATOR,
+        $taskFilePath = Path::create(
             [
                 $this->outputDirectory,
                 "{$this->fileName}Tasks.php",
             ]
         );
+        $this->taskFilePath = $taskFilePath->toString();
     }
 
     public function tearDown()

--- a/tests/Unit/Console/Command/ScheduleRunCommandTest.php
+++ b/tests/Unit/Console/Command/ScheduleRunCommandTest.php
@@ -14,7 +14,6 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Finder\SplFileInfo;
 
 class ScheduleRunCommandTest extends TestCase
 {
@@ -140,7 +139,7 @@ class ScheduleRunCommandTest extends TestCase
 
         $mocksFileInfo = \array_map(
             function ($taskFile) {
-                return $this->createConfiguredMock(SplFileInfo::class, ['getRealPath' => $taskFile]);
+                return $this->createConfiguredMock(\SplFileInfo::class, ['getRealPath' => $taskFile]);
             },
             $taskFiles
         );

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -4,6 +4,7 @@ namespace Crunz\Tests\Unit;
 
 use Carbon\Carbon;
 use Crunz\Event;
+use Crunz\Path\Path;
 use PHPUnit\Framework\TestCase;
 use SuperClosure\Serializer;
 
@@ -350,6 +351,6 @@ class EventTest extends TestCase
 
     private function buildPath(array $segments)
     {
-        return implode(DIRECTORY_SEPARATOR, $segments);
+        return Path::create($segments)->toString();
     }
 }

--- a/tests/Unit/Finder/FinderTest.php
+++ b/tests/Unit/Finder/FinderTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Crunz\Tests\Unit\Finder;
+
+use Crunz\Finder\Finder;
+use Crunz\Path\Path;
+use PHPUnit\Framework\TestCase;
+
+final class FinderTest extends TestCase
+{
+    /** @test */
+    public function findReturnsSplFileInfoCollection()
+    {
+        $path = Path::create([__DIR__, '*.php']);
+        $globIterator = new \GlobIterator(
+            $path->toString(),
+            \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::SKIP_DOTS
+        );
+
+        $finder = new Finder();
+        $files = $finder->find($path);
+
+        $this->assertCount($globIterator->count(), $files);
+        $this->assertContainsOnlyInstancesOf(\SplFileInfo::class, $files);
+    }
+}

--- a/tests/Unit/Path/PathTest.php
+++ b/tests/Unit/Path/PathTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Crunz\Tests\Unit\Path;
+
+use Crunz\Exception\CrunzException;
+use Crunz\Path\Path;
+use PHPUnit\Framework\TestCase;
+
+final class PathTest extends TestCase
+{
+    /** @test */
+    public function createRequiresAtLeastOnePath()
+    {
+        $this->expectException(CrunzException::class);
+        $this->expectExceptionMessage('At least one part expected.');
+
+        Path::create([]);
+    }
+
+    /** @test */
+    public function partsAreDelimitedByDirectorySeparator()
+    {
+        $parts = [
+            'home',
+            'crunz',
+            'bin'
+        ];
+
+        $path = Path::create($parts);
+
+        $this->assertSame(
+            \implode(DIRECTORY_SEPARATOR, $parts),
+            $path->toString()
+        );
+    }
+}

--- a/tests/Unit/Path/PathTest.php
+++ b/tests/Unit/Path/PathTest.php
@@ -23,7 +23,7 @@ final class PathTest extends TestCase
         $parts = [
             'home',
             'crunz',
-            'bin'
+            'bin',
         ];
 
         $path = Path::create($parts);


### PR DESCRIPTION
This PR removes symfony\finder dependency and introduces \Crunz\Path\Path class to ease creating file system paths delimited by OS directory separator.