### PR TITLE
Add support for symfony/lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,21 @@ $schedule->run('/usr/bin/php email.php')
  //       
 ```
 
+By default, crunz uses file based locking (if no parameters are passed to `preventOverlapping`). For alternative lock mechanisms, crunz uses the [symfony/lock](https://symfony.com/doc/current/components/lock.html) component that provides lock mechanisms with various stores. To use this component, you can pass a store to the `preventOverlapping()` method. In the following example, the file based `FlockStore` is used to provide an alternative lock file path.
+
+```php
+<?php
+//
+
+use Symfony\Component\Lock\Store\FlockStore;
+
+$store = new FlockStore(__DIR__ . '/locks);
+$schedule->run('/usr/bin/php email.php')
+         ->everyFiveMinutes()
+         ->preventOverlapping($store);
+ //
+```
+
 ## Keeping the Output
 
 Cron jobs usually have outputs, which is normally emailed to the owner of the crontab file, or the user or users set by `MAILTO` environment variable inside the crontab file.

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "symfony/console": "^2.7 || ^3.3 || ^4.0",
         "symfony/dependency-injection": "^2.7 || ^3.3 || ^4.0",
         "symfony/filesystem": "^2.7 || ^3.3 || ^4.0",
+        "symfony/lock": "^3.4 || ^4.0",
         "symfony/process": "^2.7.11 || ^3.3 || ^4.0",
         "symfony/yaml": "^2.7 || ^3.3 || ^4.0"
     },

--- a/src/Event.php
+++ b/src/Event.php
@@ -11,6 +11,9 @@ use Crunz\Path\Path;
 use Crunz\Pinger\PingableInterface;
 use Crunz\Pinger\PingableTrait;
 use SuperClosure\Serializer;
+use Symfony\Component\Lock\Factory;
+use Symfony\Component\Lock\Lock;
+use Symfony\Component\Lock\StoreInterface;
 use Symfony\Component\Process\Process;
 
 /**
@@ -64,6 +67,7 @@ class Event implements PingableInterface
      * @var Logger
      */
     public $logger;
+
     /**
      * The event's unique identifier.
      *
@@ -153,6 +157,21 @@ class Event implements PingableInterface
         'month' => 4,
         'week' => 5,
     ];
+
+    /**
+     * The symfony lock factory that is used to acquire locks. If the value is null, but preventOverlapping = true
+     * crunz falls back to filesystem locks.
+     *
+     * @var Factory|null
+     */
+    private $lockFactory;
+
+    /**
+     * Contains the timestamp of the last lock refresh.
+     *
+     * @var int
+     */
+    private $lastLockRefresh = 0;
 
     /**
      * Create a new event instance.
@@ -712,13 +731,19 @@ class Event implements PingableInterface
     /**
      * Do not allow the event to overlap each other.
      *
-     * @param string|int $safe_duration
+     * By default, the lock is acquired through file system locks. Alternatively, you can pass a symfony lock store
+     * that will be responsible for the locking.
+     *
+     * @param StoreInterface $store
      *
      * @return $this
      */
-    public function preventOverlapping()
+    public function preventOverlapping(StoreInterface $store = null)
     {
         $this->preventOverlapping = true;
+        if (null !== $store) {
+            $this->lockFactory = new Factory($store);
+        }
 
         // Skip the event if it's locked (processing)
         $this->skip(function () {
@@ -727,10 +752,7 @@ class Event implements PingableInterface
 
         // Delete the lock file when the event is completed
         $this->after(function () {
-            $lockfile = $this->lockFile();
-            if (file_exists($lockfile)) {
-                unlink($lockfile);
-            }
+            $this->releaseLock();
         });
 
         return $this;
@@ -1018,6 +1040,13 @@ class Event implements PingableInterface
      */
     public function isLocked()
     {
+        if (null !== $this->lockFactory) {
+            $lock = $this->createLockObject();
+
+            return $lock->isAcquired();
+        }
+
+        // If no symfony lock object is given, fall back to file system locks.
         $pid = $this->lastPid();
         $hasPid = (null !== $pid);
 
@@ -1048,7 +1077,67 @@ class Event implements PingableInterface
      */
     public function lockFile()
     {
+        if (null !== $this->lockFactory) {
+            throw new \BadMethodCallException('We are not using file based locking, but instead symfony/lock');
+        }
+
         return rtrim(sys_get_temp_dir(), '/') . '/crunz-' . md5($this->buildCommand());
+    }
+
+    /**
+     * If this event is prevented from overlapping, this method should be called regularly to refresh the lock.
+     */
+    public function refreshLock()
+    {
+        if (!$this->preventOverlapping) {
+            return;
+        }
+
+        if (null === $this->lockFactory) {
+            // In case of file based locking there is nothing to do.
+        }
+
+        // Refresh lock every 10s
+        $lockRefreshNeeded = $this->lastLockRefresh < (time() - 10);
+        if ($lockRefreshNeeded) {
+            $this->createLockObject()->refresh();
+        }
+    }
+
+    /**
+     * Get the symfony lock object for the task.
+     *
+     * @return Lock
+     */
+    protected function createLockObject()
+    {
+        if (null === $this->lockFactory) {
+            throw new \BadMethodCallException(
+                'No lock factory. Please call preventOverlapping() with lock storage first.'
+            );
+        }
+
+        $ttl = 30;
+
+        return $this->lockFactory->createLock('crunz-' . md5($this->buildCommand()), $ttl);
+    }
+
+    /**
+     * Release the lock after the command completed.
+     */
+    protected function releaseLock()
+    {
+        if (null !== $this->lockFactory) {
+            $lock = $this->createLockObject();
+            $lock->release();
+
+            return;
+        }
+
+        $lockfile = $this->lockFile();
+        if (file_exists($lockfile)) {
+            unlink($lockfile);
+        }
     }
 
     /**

--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -150,6 +150,8 @@ class EventRunner
 
                 /** @var Event $event */
                 foreach ($events as $eventKey => $event) {
+                    $event->refreshLock();
+
                     $proc = $event->getProcess();
                     if ($proc->isRunning()) {
                         continue;

--- a/tests/Unit/PreventOverlappingTest.php
+++ b/tests/Unit/PreventOverlappingTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Crunz\Tests\Unit;
+
+use Crunz\Configuration\Configuration;
+use Crunz\Event;
+use Crunz\EventRunner;
+use Crunz\HttpClient\HttpClientInterface;
+use Crunz\Invoker;
+use Crunz\Logger\ConsoleLoggerInterface;
+use Crunz\Logger\LoggerFactory;
+use Crunz\Mailer;
+use Crunz\Schedule;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+
+final class PreventOverlappingTest extends TestCase
+{
+    public function testPreventOverlapping()
+    {
+        $command = PHP_BINARY . ' -r "usleep(250000);"';
+
+        $schedule1 = new Schedule();
+        $event1 = $schedule1->run($command)
+            ->description('Show PHP version')
+            ->preventOverlapping()
+            ->everyMinute();
+
+        // Exact same event, might come from another schedule:run
+        $schedule2 = new Schedule();
+        $event2 = $schedule2->run($command)
+            ->description('Show PHP version')
+            ->preventOverlapping()
+            ->everyMinute();
+
+        $eventRunner = new MyEventRunner(
+            new Invoker(),
+            $this->createMock(Configuration::class),
+            $this->createMock(Mailer::class),
+            $this->createMock(LoggerFactory::class),
+            $this->createMock(HttpClientInterface::class),
+            $this->createMock(ConsoleLoggerInterface::class)
+        );
+
+        // Both events are due, none is locked yet
+        $this->assertEquals([$event1], $schedule1->dueEvents(new \DateTimeZone(date_default_timezone_get())));
+        $this->assertEquals([$event2], $schedule2->dueEvents(new \DateTimeZone(date_default_timezone_get())));
+
+        // Start schedule, so that event1 will be locked
+        $eventRunner->handle(new NullOutput(), [$schedule1]);
+
+        // Event is locked and therefore not due (even over the boundaries of multiple independent events and schedules)
+        $this->assertEquals([], $schedule1->dueEvents(new \DateTimeZone(date_default_timezone_get())));
+        $this->assertEquals([], $schedule2->dueEvents(new \DateTimeZone(date_default_timezone_get())));
+
+        // Assert only one process is running
+        $this->assertTrue($event1->getProcess()->isRunning());
+        $this->assertNull($event2->getProcess(), 'Event 2 should not be running');
+
+        // Assert lock on both events
+        $this->assertTrue($event1->isLocked());
+        $this->assertTrue($event2->isLocked());
+
+        // Wait until the process finished
+        while ($event1->isLocked()) {
+            $eventRunner->manageStartedEvents();
+            usleep(10000);
+        }
+
+        // Assert both locks were removed
+        $this->assertFalse($event1->isLocked());
+        $this->assertFalse($event2->isLocked());
+    }
+}
+
+class MyEventRunner extends EventRunner
+{
+    /**
+     * Manage the running processes.
+     *
+     * This is a simplified version that checks whether the processes are still running and returns afterwards.
+     *
+     * This adoption is non-blocking / does not wait for all processes to finish, because otherwise we could not test
+     * the locking in a single threaded manner.
+     */
+    public function manageStartedEvents()
+    {
+        foreach ($this->schedules as $scheduleKey => $schedule) {
+            $events = $schedule->events();
+
+            /** @var Event $event */
+            foreach ($events as $eventKey => $event) {
+                $proc = $event->getProcess();
+                if ($proc->isRunning()) {
+                    continue;
+                }
+
+                // Dismiss the event after it's finished
+                $this->invoke($event->afterCallbacks());
+                $schedule->dismissEvent($eventKey);
+            }
+
+            if (!\count($schedule->events())) {
+                $this->invoke($schedule->afterCallbacks());
+                unset($this->schedules[$scheduleKey]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the ability to use a symfony/lock storage to prevent command overlapping, as discussed in #125.

I did not remove the file based locking, as this might be BC break (because of the lockFile() method etc., which is not private). However, this could be removed with the next major release.

This should also solve the request of @IkeLutra, because he can now use the FlockStorage and define the path.

Additionally, I added a unit test that verifies that the task lockig is working properly.