### PR TITLE
Run tests on PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
     - 7.0
     - 7.1
     - 7.2
+    - 7.3
     - nightly
 
 matrix:


### PR DESCRIPTION
On Travis test against PHP 7.3 explicitly because nightly is 7.4-dev now.