### PR TITLE
 fix incorrect timezone in log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,11 @@ suffix: Tasks.php
 # and will result in exception in 2.0 version.
 timezone: ~
 
+# This option define which timezone should be used for log files
+# If false, system default timezone will be used
+# If true, the timezone in config file that is used to calculate task run time will be used
+timezone_log: false
+
 # By default the errors are not logged by Crunz
 # You may set the value to true for logging the errors
 log_errors: false

--- a/crunz.yml
+++ b/crunz.yml
@@ -16,6 +16,11 @@ suffix: Tasks.php
 # and will result in exception in 2.0 version.
 timezone: ~
 
+# This option define which timezone should be used for log files
+# If false, system default timezone will be used
+# If true, the timezone in config file that is used to calculate task run time will be used
+timezone_log: false
+
 # By default the errors are not logged by Crunz
 # You may set the value to true for logging the errors
 log_errors: false

--- a/src/Configuration/Definition.php
+++ b/src/Configuration/Definition.php
@@ -36,6 +36,10 @@ class Definition implements ConfigurationInterface
                     ->info('Timezone used to calculate task run date')
                 ->end()
 
+                ->scalarNode('timezone_log')
+                ->info('Whether configured timezone will be used for logs')
+                ->end()
+
                 ->booleanNode('log_errors')
                     ->defaultFalse()
                     ->info('Flag for logging errors' . PHP_EOL)

--- a/src/Configuration/Definition.php
+++ b/src/Configuration/Definition.php
@@ -36,7 +36,8 @@ class Definition implements ConfigurationInterface
                     ->info('Timezone used to calculate task run date')
                 ->end()
 
-                ->scalarNode('timezone_log')
+                ->booleanNode('timezone_log')
+                ->defaultFalse()
                 ->info('Whether configured timezone will be used for logs')
                 ->end()
 

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -10,9 +10,21 @@ class LoggerFactory
     /** @var Configuration */
     private $configuration;
 
+    /**
+     * LoggerFactory constructor.
+     *
+     * @param Configuration $configuration
+     *
+     * @throws \Exception if the timezone supplied in configuration is not recognised as a valid timezone
+     */
     public function __construct(Configuration $configuration)
     {
         $this->configuration = $configuration;
+        $timezone = $configuration->get('timezone');
+        $timezoneLog = $configuration->get('timezone_log');
+        if ($timezoneLog and $timezone) {
+            MonologLogger::setTimezone(new \DateTimeZone($timezone));
+        }
     }
 
     /**

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -13,10 +13,6 @@ class LoggerFactory
     public function __construct(Configuration $configuration)
     {
         $this->configuration = $configuration;
-        $timezone = $this->configuration->get('timezone');
-        if ($timezone) {
-            MonologLogger::setTimezone(new \DateTimeZone($timezone));
-        }
     }
 
     /**

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -24,6 +24,8 @@ class LoggerFactory
         $timezoneLog = $configuration->get('timezone_log');
         if ($timezoneLog and $timezone) {
             MonologLogger::setTimezone(new \DateTimeZone($timezone));
+        } else {
+            MonologLogger::setTimezone(new \DateTimeZone('UTC'));
         }
     }
 

--- a/src/Logger/LoggerFactory.php
+++ b/src/Logger/LoggerFactory.php
@@ -13,6 +13,10 @@ class LoggerFactory
     public function __construct(Configuration $configuration)
     {
         $this->configuration = $configuration;
+        $timezone = $this->configuration->get('timezone');
+        if ($timezone) {
+            MonologLogger::setTimezone(new \DateTimeZone($timezone));
+        }
     }
 
     /**

--- a/tests/Unit/Logger/FileLoggerTest.php
+++ b/tests/Unit/Logger/FileLoggerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Crunz\Tests\Unit\Logger;
+
+use Crunz\Configuration\Configuration;
+use Crunz\Configuration\ConfigurationParserInterface;
+use Crunz\Filesystem\FilesystemInterface;
+use Crunz\Logger\Logger;
+use Crunz\Logger\LoggerFactory;
+use Crunz\Tests\TestCase\TemporaryFile;
+use Monolog\Logger as MonologLogger;
+use PHPUnit\Framework\TestCase;
+
+final class FileLoggerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function invalidTimezoneThrowException()
+    {
+        $configuration = $this->createConfiguration(['timezone' => 'invalid_ts', 'timezone_log' => true]);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageRegExp('*bad timezone*');
+        new LoggerFactory($configuration);
+    }
+
+    /**
+     * @test
+     */
+    public function crunzLoggerTimezoneIsConfiguredTimezone()
+    {
+        $expectedTimezone = 'Asia/Tehran';
+        $defaultTimezone = 'UTC';
+        $crunzLogger = $this->createCrunzLogger(['timezone' => $expectedTimezone, 'timezone_log' => true]);
+        /** @var MonologLogger $monolog */
+        $monologLogger = $this->readAttribute($crunzLogger, 'logger');
+        /** @var \DateTimeZone|null $loggerTimezone */
+        $loggerTimezone = $this->readAttribute($monologLogger, 'timezone');
+
+        $this->assertSame($expectedTimezone, $loggerTimezone->getName());
+        $this->assertNotSame($defaultTimezone, $loggerTimezone->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function crunzLoggerTimezoneIsDefaultWhenTimezoneLogOptionIsFalse()
+    {
+        $expectedTimezone = 'Asia/Tehran';
+        $defaultTimezone = 'UTC';
+        $crunzLogger = $this->createCrunzLogger(['timezone' => $expectedTimezone, 'timezone_log' => false]);
+        /** @var MonologLogger $monolog */
+        $monologLogger = $this->readAttribute($crunzLogger, 'logger');
+        /** @var \DateTimeZone|null $loggerTimezone */
+        $loggerTimezone = $this->readAttribute($monologLogger, 'timezone');
+        $this->assertNotSame($expectedTimezone, $loggerTimezone->getName());
+        $this->assertSame($defaultTimezone, $loggerTimezone->getName());
+    }
+
+    /** @return Configuration */
+    private function createConfiguration(array $config = [])
+    {
+        $mockConfigurationParser = $this->createMock(ConfigurationParserInterface::class);
+        $mockConfigurationParser
+            ->method('parseConfig')
+            ->willReturn($config)
+        ;
+
+        return new Configuration(
+            $mockConfigurationParser,
+            $this->createMock(FilesystemInterface::class)
+        );
+    }
+
+    /** @return Logger */
+    private function createCrunzLogger(array $config = [])
+    {
+        $configuration = $this->createConfiguration($config);
+        $tempFile = new TemporaryFile();
+        $loggerFactory = new LoggerFactory($configuration);
+
+        return $loggerFactory->create(['debug' => $tempFile->filePath()]);
+    }
+}

--- a/tests/crunz.yml
+++ b/tests/crunz.yml
@@ -1,6 +1,7 @@
 source: tasks
 suffix: Tasks.php
 timezone: UTC
+timezone_log: false
 log_errors: false
 errors_log_file: ~
 log_output: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed ticket | #175 

Crunz timezone in log files is not depending on timezone that is used to calculate task run time.
Because crunz logs my task related event. I set timezone for my tasks, and crunz uses this timezone to run task, thus any logs that related to this task, should be log in configured timezone.
