### PR TITLE
Fix deprecation messages not showing

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -2,10 +2,13 @@
 
 require_once __DIR__ . '/vendor/autoload.php';
 
+$envFlags = new \Crunz\EnvFlags\EnvFlags();
+$envFlags->disableDeprecationHandler();
+
 if (\strpos(\getcwd(), 'tests') !== false) {
     return;
 }
 
 if (!\chdir('tests')) {
-    throw new RuntimeException("Unable to change currenjt directory to 'tests'.");
+    throw new RuntimeException("Unable to change current directory to 'tests'.");
 }

--- a/config/services.php
+++ b/config/services.php
@@ -256,6 +256,11 @@ $container
     )
 ;
 
+$container
+    ->register(\Crunz\EnvFlags\EnvFlags::class, \Crunz\EnvFlags\EnvFlags::class)
+    ->setPublic(true)
+;
+
 foreach ($simpleServices as $id => $simpleService) {
     if (!\is_string($id)) {
         $id = $simpleService;

--- a/src/Application.php
+++ b/src/Application.php
@@ -2,6 +2,7 @@
 
 namespace Crunz;
 
+use Crunz\EnvFlags\EnvFlags;
 use Crunz\Path\Path;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\FileLocator;
@@ -221,6 +222,14 @@ class Application extends SymfonyApplication
 
     private function registerDeprecationHandler()
     {
+        /** @var EnvFlags $envFlags */
+        $envFlags = $this->container
+            ->get(EnvFlags::class);
+
+        if (!$envFlags->isDeprecationHandlerEnabled()) {
+            return;
+        }
+
         $io = $this->container
             ->get(SymfonyStyle::class);
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -58,6 +58,7 @@ class Application extends SymfonyApplication
         parent::__construct($appName, $appVersion);
 
         $this->initializeContainer();
+        $this->registerDeprecationHandler();
 
         foreach (self::COMMANDS as $commandClass) {
             $command = $this->container
@@ -79,8 +80,6 @@ class Application extends SymfonyApplication
             $input = $this->container
                 ->get(InputInterface::class);
         }
-
-        $this->registerDeprecationHandler();
 
         return parent::run($input, $output);
     }

--- a/src/EnvFlags/EnvFlags.php
+++ b/src/EnvFlags/EnvFlags.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Crunz\EnvFlags;
+
+use Crunz\Exception\CrunzException;
+
+final class EnvFlags
+{
+    const DEPRECATION_HANDLER_FLAG = 'CRUNZ_DEPRECATION_HANDLER';
+
+    /** @return bool */
+    public function isDeprecationHandlerEnabled()
+    {
+        $registerHandlerEnv = \getenv(self::DEPRECATION_HANDLER_FLAG, true);
+        $registerHandler = true;
+
+        if (false !== $registerHandlerEnv) {
+            $registerHandler = \filter_var($registerHandlerEnv, FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return $registerHandler;
+    }
+
+    /** @throws CrunzException When enabling deprecation handler fails */
+    public function enableDeprecationHandler()
+    {
+        if (false === \putenv(self::DEPRECATION_HANDLER_FLAG . '=1')) {
+            throw new CrunzException('Enabling deprecation handler failed.');
+        }
+    }
+
+    /** @throws CrunzException When disabling deprecation handler fails */
+    public function disableDeprecationHandler()
+    {
+        if (false === \putenv(self::DEPRECATION_HANDLER_FLAG . '=0')) {
+            throw new CrunzException('Enabling deprecation handler failed.');
+        }
+    }
+}

--- a/tests/EndToEnd/DeprecationMessagesTest.php
+++ b/tests/EndToEnd/DeprecationMessagesTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Crunz\Tests\EndToEnd;
+
+use Crunz\Path\Path;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class DeprecationMessagesTest extends TestCase
+{
+    /** @test */
+    public function earlyDeprecationShouldBeVisible()
+    {
+        $path = Path::create(
+            [
+                'bin',
+                'deprecation-application',
+                'crunz',
+            ]
+        );
+
+        $process = new Process($path->toString());
+        $process->start();
+        $process->wait();
+
+        $this->assertSame(0, $process->getExitCode());
+        $this->assertContains('[Deprecation] Test deprecation', $process->getOutput());
+    }
+}

--- a/tests/Unit/EnvFlags/EnvFlagsTest.php
+++ b/tests/Unit/EnvFlags/EnvFlagsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Crunz\Tests\Unit\EnvFlags;
+
+use Crunz\EnvFlags\EnvFlags;
+use PHPUnit\Framework\TestCase;
+
+final class EnvFlagsTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider statusProvider
+     */
+    public function deprecationHandlerStatusIsCorrect($flagValue, $expectedEnabled)
+    {
+        \putenv(EnvFlags::DEPRECATION_HANDLER_FLAG . "={$flagValue}");
+
+        $envFlags = new EnvFlags();
+        $this->assertSame($expectedEnabled, $envFlags->isDeprecationHandlerEnabled());
+    }
+
+    /** @test */
+    public function deprecationHandlerCanBeDisabled()
+    {
+        $envFlags = new EnvFlags();
+        $envFlags->disableDeprecationHandler();
+
+        $this->assertFlagValue('0');
+    }
+
+    /** @test */
+    public function deprecationHandlerCanBeEnabled()
+    {
+        $envFlags = new EnvFlags();
+        $envFlags->enableDeprecationHandler();
+
+        $this->assertFlagValue('1');
+    }
+
+    public function statusProvider()
+    {
+        yield 'true' => [
+            '1',
+            true,
+        ];
+
+        yield 'false' => [
+            '0',
+            false,
+        ];
+    }
+
+    private function assertFlagValue($expectedValue)
+    {
+        $actualValue = \getenv(EnvFlags::DEPRECATION_HANDLER_FLAG);
+        $this->assertSame($expectedValue, $actualValue);
+    }
+}

--- a/tests/bin/bootstrap.php
+++ b/tests/bin/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+$root = \dirname(\dirname(__DIR__));
+$autoloaderPath = \implode(
+    DIRECTORY_SEPARATOR,
+    [
+        $root,
+        'vendor',
+        'autoload.php',
+    ]
+);
+
+require_once $autoloaderPath;

--- a/tests/bin/deprecation-application/crunz
+++ b/tests/bin/deprecation-application/crunz
@@ -1,0 +1,15 @@
+#!/usr/bin/env php
+<?php
+
+require_once \dirname(__DIR__) . DIRECTORY_SEPARATOR . 'bootstrap.php';
+
+// Enable Crunz deprecation handler because
+// it is disabled in test env
+\putenv('CRUNZ_DEPRECATION_HANDLER=1');
+
+$application = new \Crunz\Application('Crunz', 'dev-test');
+
+// Trigger deprecation early to test handler registration
+@trigger_error('Test deprecation', E_USER_DEPRECATED);
+
+$application->run();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #179  <!-- #-prefixed issue number(s), if any -->

`registerDeprecationHandler` moved just after `initializeContainer`, now every deprecation should be handled by Crunz deprecation handler.