### PR TITLE
Make "container debug" configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,21 @@ vendor/bin/crunz make:task --help
 
 ```
 
+## Development ENV flags
+
+Below env flags should be used only while development.
+Typical end-users do not need to, and should not, change them.
+
+### `CRUNZ_CONTAINER_DEBUG`
+
+Flag used to enable/disable container debug mode, useful only for development.
+Enabled by default in `docker-compose`.
+
+### `CRUNZ_DEPRECATION_HANDLER`
+
+Flag used to enable/disable Crunz deprecation handler, useful only for integration tests.
+Disabled by default for tests.
+
 ## Contributing
 
 ### Which branch should I choose?

--- a/config/services.php
+++ b/config/services.php
@@ -256,11 +256,6 @@ $container
     )
 ;
 
-$container
-    ->register(\Crunz\EnvFlags\EnvFlags::class, \Crunz\EnvFlags\EnvFlags::class)
-    ->setPublic(true)
-;
-
 foreach ($simpleServices as $id => $simpleService) {
     if (!\is_string($id)) {
         $id = $simpleService;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
         build:
             context: ./docker/php56
         working_dir: /var/www/html
+        environment:
+            CRUNZ_CONTAINER_DEBUG: 1
         command: >
             sh -c "
                 chown -R www-data:www-data /var/www/.composer \
@@ -20,6 +22,8 @@ services:
         build:
             context: ./docker/php71
         working_dir: /var/www/html
+        environment:
+            CRUNZ_CONTAINER_DEBUG: 1
         command: >
             sh -c "
                 chown -R www-data:www-data /var/www/.composer \

--- a/src/Application.php
+++ b/src/Application.php
@@ -49,6 +49,8 @@ class Application extends SymfonyApplication
 
     /** @var Container */
     private $container;
+    /** @var EnvFlags */
+    private $envFlags;
 
     /**
      * Instantiate the class.
@@ -56,6 +58,8 @@ class Application extends SymfonyApplication
     public function __construct($appName, $appVersion)
     {
         parent::__construct($appName, $appVersion);
+
+        $this->envFlags = new EnvFlags();
 
         $this->initializeContainer();
         $this->registerDeprecationHandler();
@@ -221,11 +225,10 @@ class Application extends SymfonyApplication
 
     private function registerDeprecationHandler()
     {
-        /** @var EnvFlags $envFlags */
-        $envFlags = $this->container
-            ->get(EnvFlags::class);
+        $isDeprecationHandlerEnabled = $this->envFlags
+            ->isDeprecationHandlerEnabled();
 
-        if (!$envFlags->isDeprecationHandlerEnabled()) {
+        if (!$isDeprecationHandlerEnabled) {
             return;
         }
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -91,6 +91,8 @@ class Application extends SymfonyApplication
     private function initializeContainer()
     {
         $containerCacheDirWritable = $this->createBaseCacheDirectory();
+        $isContainerDebugEnabled = $this->envFlags
+            ->isContainerDebugEnabled();
 
         if ($containerCacheDirWritable) {
             $class = 'CrunzContainer';
@@ -101,7 +103,7 @@ class Application extends SymfonyApplication
                     "{$class}.php",
                 ]
             );
-            $cache = new ConfigCache($cachePath->toString(), true);
+            $cache = new ConfigCache($cachePath->toString(), $isContainerDebugEnabled);
 
             if (!$cache->isFresh()) {
                 $containerBuilder = $this->buildContainer();

--- a/src/EnvFlags/EnvFlags.php
+++ b/src/EnvFlags/EnvFlags.php
@@ -7,6 +7,7 @@ use Crunz\Exception\CrunzException;
 final class EnvFlags
 {
     const DEPRECATION_HANDLER_FLAG = 'CRUNZ_DEPRECATION_HANDLER';
+    const CONTAINER_DEBUG_FLAG = 'CRUNZ_CONTAINER_DEBUG';
 
     /** @return bool */
     public function isDeprecationHandlerEnabled()
@@ -21,6 +22,35 @@ final class EnvFlags
         return $registerHandler;
     }
 
+    /** @return bool */
+    public function isContainerDebugEnabled()
+    {
+        $containerDebugEnv = \getenv(self::CONTAINER_DEBUG_FLAG, true);
+        $containerDebug = false;
+
+        if (false !== $containerDebugEnv) {
+            $containerDebug = \filter_var($containerDebugEnv, FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return $containerDebug;
+    }
+
+    /** @throws CrunzException When disabling deprecation handler fails */
+    public function disableContainerDebug()
+    {
+        if (false === \putenv(self::CONTAINER_DEBUG_FLAG . '=0')) {
+            throw new CrunzException('Disabling container debug failed.');
+        }
+    }
+
+    /** @throws CrunzException When enabling deprecation handler fails */
+    public function enableContainerDebug()
+    {
+        if (false === \putenv(self::CONTAINER_DEBUG_FLAG . '=1')) {
+            throw new CrunzException('Enabling container debug failed.');
+        }
+    }
+
     /** @throws CrunzException When enabling deprecation handler fails */
     public function enableDeprecationHandler()
     {
@@ -33,7 +63,7 @@ final class EnvFlags
     public function disableDeprecationHandler()
     {
         if (false === \putenv(self::DEPRECATION_HANDLER_FLAG . '=0')) {
-            throw new CrunzException('Enabling deprecation handler failed.');
+            throw new CrunzException('Disabling deprecation handler failed.');
         }
     }
 }

--- a/tests/TestCase/EndToEnd/Environment/Environment.php
+++ b/tests/TestCase/EndToEnd/Environment/Environment.php
@@ -49,9 +49,17 @@ final class Environment
     {
         $composerLock = Path::fromStrings('composer.lock');
         $composerJson = Path::fromStrings('composer.json');
+        $baseCacheDir = Path::create(
+            [
+                \sys_get_temp_dir(),
+                '.crunz',
+            ]
+        );
 
         $this->filesystem
             ->removeDirectory($this->rootDirectory(), [$composerLock, $composerJson]);
+        $this->filesystem
+            ->removeDirectory($baseCacheDir->toString());
     }
 
     private function setUp()

--- a/tests/TestCase/EndToEnd/Environment/Environment.php
+++ b/tests/TestCase/EndToEnd/Environment/Environment.php
@@ -99,24 +99,15 @@ final class Environment
         );
         $process = $this->createProcess($fullCommand->toString(), $cwd);
         $windowsEnvsHack = $isWindows && !$process->isInheritEnvVarsSupported();
-        $deprecationHandlerEnabled = $this->envFlags
-            ->isDeprecationHandlerEnabled();
-        $containerDebugEnabled = $this->envFlags
-            ->isContainerDebugEnabled();
 
         // @TODO Disable this hack in v2.
-        if ($windowsEnvsHack && !$deprecationHandlerEnabled) {
+        if ($windowsEnvsHack) {
             $this->envFlags
                 ->enableDeprecationHandler();
-        } else {
-            $process->setEnv([EnvFlags::DEPRECATION_HANDLER_FLAG => '1']);
-        }
-
-        // @TODO Disable this hack in v2.
-        if ($windowsEnvsHack && $containerDebugEnabled) {
             $this->envFlags
                 ->disableContainerDebug();
         } else {
+            $process->setEnv([EnvFlags::DEPRECATION_HANDLER_FLAG => '1']);
             $process->setEnv([EnvFlags::CONTAINER_DEBUG_FLAG => '0']);
         }
 
@@ -124,15 +115,11 @@ final class Environment
         $process->wait();
 
         // @TODO Remove this hack in v2.
-        if ($windowsEnvsHack && !$deprecationHandlerEnabled) {
-            $this->envFlags
-                ->disableDeprecationHandler();
-        }
-
-        // @TODO Remove this hack in v2.
-        if ($windowsEnvsHack && $containerDebugEnabled) {
+        if ($windowsEnvsHack) {
             $this->envFlags
                 ->enableContainerDebug();
+            $this->envFlags
+                ->disableDeprecationHandler();
         }
 
         return $process;

--- a/tests/TestCase/EndToEnd/Environment/Environment.php
+++ b/tests/TestCase/EndToEnd/Environment/Environment.php
@@ -101,6 +101,8 @@ final class Environment
         $windowsEnvsHack = $isWindows && !$process->isInheritEnvVarsSupported();
         $deprecationHandlerEnabled = $this->envFlags
             ->isDeprecationHandlerEnabled();
+        $containerDebugEnabled = $this->envFlags
+            ->isContainerDebugEnabled();
 
         // @TODO Disable this hack in v2.
         if ($windowsEnvsHack && !$deprecationHandlerEnabled) {
@@ -110,12 +112,27 @@ final class Environment
             $process->setEnv([EnvFlags::DEPRECATION_HANDLER_FLAG => '1']);
         }
 
+        // @TODO Disable this hack in v2.
+        if ($windowsEnvsHack && $containerDebugEnabled) {
+            $this->envFlags
+                ->disableContainerDebug();
+        } else {
+            $process->setEnv([EnvFlags::CONTAINER_DEBUG_FLAG => '0']);
+        }
+
         $process->start();
         $process->wait();
 
+        // @TODO Remove this hack in v2.
         if ($windowsEnvsHack && !$deprecationHandlerEnabled) {
             $this->envFlags
                 ->disableDeprecationHandler();
+        }
+
+        // @TODO Remove this hack in v2.
+        if ($windowsEnvsHack && $containerDebugEnabled) {
+            $this->envFlags
+                ->enableContainerDebug();
         }
 
         return $process;

--- a/tests/Unit/EnvFlags/EnvFlagsTest.php
+++ b/tests/Unit/EnvFlags/EnvFlagsTest.php
@@ -25,7 +25,7 @@ final class EnvFlagsTest extends TestCase
         $envFlags = new EnvFlags();
         $envFlags->disableDeprecationHandler();
 
-        $this->assertFlagValue('0');
+        $this->assertFlagValue(EnvFlags::DEPRECATION_HANDLER_FLAG, '0');
     }
 
     /** @test */
@@ -34,7 +34,37 @@ final class EnvFlagsTest extends TestCase
         $envFlags = new EnvFlags();
         $envFlags->enableDeprecationHandler();
 
-        $this->assertFlagValue('1');
+        $this->assertFlagValue(EnvFlags::DEPRECATION_HANDLER_FLAG, '1');
+    }
+
+    /**
+     * @test
+     * @dataProvider containerDebugProvider
+     */
+    public function containerDebugFlagIsCorrect($flagValue, $expectedEnabled)
+    {
+        \putenv(EnvFlags::CONTAINER_DEBUG_FLAG . "={$flagValue}");
+
+        $envFlags = new EnvFlags();
+        $this->assertSame($expectedEnabled, $envFlags->isContainerDebugEnabled());
+    }
+
+    /** @test */
+    public function containerDebugCanBeDisabled()
+    {
+        $envFlags = new EnvFlags();
+        $envFlags->disableContainerDebug();
+
+        $this->assertFlagValue(EnvFlags::CONTAINER_DEBUG_FLAG, '0');
+    }
+
+    /** @test */
+    public function containerDebugCanBeEnabled()
+    {
+        $envFlags = new EnvFlags();
+        $envFlags->enableContainerDebug();
+
+        $this->assertFlagValue(EnvFlags::CONTAINER_DEBUG_FLAG, '1');
     }
 
     public function statusProvider()
@@ -50,9 +80,22 @@ final class EnvFlagsTest extends TestCase
         ];
     }
 
-    private function assertFlagValue($expectedValue)
+    public function containerDebugProvider()
     {
-        $actualValue = \getenv(EnvFlags::DEPRECATION_HANDLER_FLAG);
+        yield 'true' => [
+            '1',
+            true,
+        ];
+
+        yield 'false' => [
+            '0',
+            false,
+        ];
+    }
+
+    private function assertFlagValue($flag, $expectedValue)
+    {
+        $actualValue = \getenv($flag);
         $this->assertSame($expectedValue, $actualValue);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | no

By default "container debug" was enabled, but there is no need to keep it enabled for end users. This PR disables it for end users and enabled only for development containers, by the way some CPU cycles and disk IO should be saved also on Crunz start up.
