### PR TITLE
Add missing upgrade guides

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,3 +13,24 @@ Cron job also should be changed:
 ```bash
 * * * * * cd /var/www/project && vendor/bin/crunz schedule:run
 ```
+
+# Upgrading from v1.9 to v1.10
+
+### Do not pass more than five parts to `Crunz\Event::cron()`
+
+Example correct call:
+```yaml
+$event = new Crunz\Event;
+$event->cron('0 * * * *');
+```
+
+# Upgrading from v1.7 to v1.8
+
+### Add `timezone` to your `crunz.yml`
+
+Example config file:
+```yaml
+source: tasks
+suffix: Tasks.php
+timezone: Europe/Warsaw
+```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | no

This PR add two missing upgrades, from `v1.7` to `v1.8` and from `v1.9` to `v1.10`.
