### PR TITLE
Move symfony/debug to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/config": "^3.4 || ^4.1",
         "symfony/console": "^3.4 || ^4.1",
-        "symfony/debug": "^3.4.22 || ^4.1",
         "symfony/dependency-injection": "^3.4 || ^4.1",
         "symfony/filesystem": "^3.4 || ^4.1",
         "symfony/lock": "^3.4 || ^4.0",
@@ -44,6 +43,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "bamarni/composer-bin-plugin": "^1.2",
+        "symfony/debug": "^3.4.22 || ^4.1",
         "symfony/var-dumper": "^3.4 || ^4.1"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | no

There is no need to require `symfony/debug` at least on version `3.4.22` for non-dev usages
