### PR TITLE
More than five parts cron expressions will throw exception

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -14,6 +14,7 @@ use Crunz\Path\Path;
 use Crunz\Pinger\PingableInterface;
 use Crunz\Pinger\PingableTrait;
 use Crunz\Process\Process;
+use Crunz\Task\TaskException;
 use SuperClosure\Serializer;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Factory;
@@ -344,11 +345,9 @@ class Event implements PingableInterface
     /**
      * The Cron expression representing the event's frequency.
      *
-     * @param string $expression
-     *
-     * @return $this
+     * @throws TaskException
      */
-    public function cron($expression)
+    public function cron(string $expression): self
     {
         $parts = \preg_split(
             '/\s/',
@@ -357,12 +356,8 @@ class Event implements PingableInterface
             PREG_SPLIT_NO_EMPTY
         );
 
-        // @TODO Throw exception in v2
         if (\count($parts) > 5) {
-            @\trigger_error(
-                'Using cron expression with more than 5 parts is deprecated from v1.9 and will result in exception in v2.0. If you are using dragonmantank/cron-expression package be aware that passing more than five parts to this method will result in exception.',
-                E_USER_DEPRECATED
-            );
+            throw new TaskException("Expression '{$expression}' has more than five parts and this is not allowed.");
         }
 
         $this->expression = $expression;

--- a/src/Task/TaskException.php
+++ b/src/Task/TaskException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Task;
+
+use Crunz\Exception\CrunzException;
+
+class TaskException extends CrunzException
+{
+}

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -12,7 +12,7 @@ use SuperClosure\Serializer;
 use Symfony\Component\Lock\Store\SemaphoreStore;
 use Symfony\Component\Lock\StoreInterface;
 
-class EventTest extends TestCase
+final class EventTest extends TestCase
 {
     /**
      * The default configuration timezone.

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Crunz\Tests\Unit;
 
 use Crunz\Event;
+use Crunz\Task\TaskException;
 use Crunz\Tests\TestCase\TestClock;
 use PHPUnit\Framework\TestCase;
 use SuperClosure\Serializer;
@@ -201,17 +202,14 @@ final class EventTest extends TestCase
         $this->assertTrue($e->cron('* * * * *')->skip(function () { return false; })->isDue($timezone));
     }
 
-    /**
-     * @test
-     * @group legacy
-     * @expectedDeprecation Using cron expression with more than 5 parts is deprecated from v1.9 and will result in exception in v2.0. If you are using dragonmantank/cron-expression package be aware that passing more than five parts to this method will result in exception.
-     */
-    public function moreThanFivePartsInCronExpressionResultsInDeprecationNotice(): void
+    /** @test */
+    public function moreThanFivePartsInCronExpressionResultsInException(): void
     {
+        $this->expectException(TaskException::class);
+        $this->expectExceptionMessage("Expression '* * * * * *' has more than five parts and this is not allowed.");
+
         $e = new Event(1, 'php foo -v');
         $e->cron('* * * * * *');
-
-        $this->assertTrue(true);
     }
 
     public function testBuildCommand(): void

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Crunz\Tests\Unit;
 
 use Crunz\Event;
-use Crunz\Path\Path;
 use Crunz\Tests\TestCase\TestClock;
 use PHPUnit\Framework\TestCase;
 use SuperClosure\Serializer;
@@ -431,10 +430,5 @@ final class EventTest extends TestCase
     private function isWindows()
     {
         return DIRECTORY_SEPARATOR === '\\';
-    }
-
-    private function buildPath(array $segments)
-    {
-        return Path::create($segments)->toString();
     }
 }

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -71,8 +71,6 @@ final class EventTest extends TestCase
      */
     public function testUnitMethods(): void
     {
-        $id = \uniqid();
-
         $e = new Event($this->id, 'php foo');
         $this->assertEquals('0 * * * *', $e->hourly()->getExpression());
 
@@ -407,7 +405,7 @@ final class EventTest extends TestCase
         $this->assertFalse($event2->isDue(new \DateTimeZone('UTC')));
     }
 
-    private function createPreventOverlappingEvent(StoreInterface $store = null)
+    private function createPreventOverlappingEvent(StoreInterface $store = null): Event
     {
         $command = "php -r 'sleep(2);'";
 
@@ -427,7 +425,7 @@ final class EventTest extends TestCase
         $property->setValue($testClock);
     }
 
-    private function isWindows()
+    private function isWindows(): bool
     {
         return DIRECTORY_SEPARATOR === '\\';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | no

Passing more than five parts to `Crunz\Event::cron()` will now throw exception, as it was deprecated in `v1.9`.