### PR TITLE
#207 - Add Vendor/Bin as source for Autoload discovery

### DIFF
--- a/crunz
+++ b/crunz
@@ -35,6 +35,14 @@ $autoloadPaths = [
             'autoload.php'
         ]
     ),
+    // Vendor/Bin
+    $generatePath(
+        [
+            _DIR_,
+            '..',
+            'autoload.php'
+        ]
+    ),
     // Local dev
     $generatePath(
         [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #207

<!--
Added a new path to the autoload possible paths to allow it to be found when crunz itself is in vendor/bin rather than the symlink
-->
