### PR TITLE
Remove 'mail' transport

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,11 @@
+# Upgrading from v1.12 to v2.0
+
+## Stop using `mail` transport for mailer
+
+As of `v6.0` SwiftMailer dropped support for `mail` transport,
+so `Crunz` `v2.0` won't support it either,
+please use `smtp` or `sendmail` transport.
+
 # Upgrading from v1.11 to v1.12
 
 ## Always return `\Crunz\Schedule` from task files

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,27 +14,6 @@ parameters:
         -
             message: '#Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition::children\(\)#'
             path: src/Configuration/Definition.php
-        -
-            message: '#Call to an undefined static method Swift_Mailer::newInstance()#'
-            path: src/Mailer.php
-        -
-            message: '#Call to an undefined static method Swift_SmtpTransport::newInstance()#'
-            path: src/Mailer.php
-        -
-            message: '#Return typehint of method Crunz\\Mailer::getMailTransport\(\) has invalid type Swift_MailTransport#'
-            path: src/Mailer.php
-        -
-            message: '#Call to static method newInstance\(\) on an unknown class Swift_MailTransport#'
-            path: src/Mailer.php
-        -
-            message: '#Call to an undefined static method Swift_SendmailTransport::newInstance\(\)#'
-            path: src/Mailer.php
-        -
-            message: '#Call to an undefined static method Swift_Message::newInstance\(\)#'
-            path: src/Mailer.php
-        -
-            message: '#Parameter \#1 \$transport of class Swift_Mailer constructor expects Swift_Transport#'
-            path: src/Mailer.php
         - '#Constant CRUNZ_BIN not found#'
         -
             message: '#Variable \$configFile might not be defined#'
@@ -46,9 +25,6 @@ parameters:
             message: '#Call to an undefined method Crunz\\Event::every.*(Minutes|Hours)\(\)#'
             path: tests/Unit/EventTest.php
         - '#Method Crunz\\(Event|Schedule|Tests\\Unit\\Pingable)::(pingBefore|thenPing)\(\) should return \$this\(Crunz\\Pinger\\PingableInterface\)#'
-        -
-            message: "#Call to function method_exists\\(\\) with 'Swift([a-zA-Z_…]+)?' and 'newInstance' will always evaluate to false#"
-            path: src/Mailer.php
         -
             message: "#Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component…' and '(fromShellCommandline|inheritEnvironmentV…)' will always evaluate to false#"
             path: src/Process/Process.php

--- a/src/Exception/MailerException.php
+++ b/src/Exception/MailerException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Exception;
+
+final class MailerException extends CrunzException
+{
+}

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -7,7 +7,7 @@ namespace Crunz;
 use Crunz\Configuration\Configuration;
 use Crunz\Exception\MailerException;
 
-final class Mailer
+class Mailer
 {
     /** @var \Swift_Mailer|null */
     protected $mailer;

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Crunz;
 
 use Crunz\Configuration\Configuration;
+use Crunz\Exception\MailerException;
 
 class Mailer
 {
@@ -52,8 +53,11 @@ class Mailer
             break;
 
             case 'mail':
-            $transport = $this->getMailTransport();
-            break;
+                throw new MailerException(
+                    "'mail' transport is no longer supported, please use 'smtp' or 'sendmail' transport."
+                );
+
+                break;
 
             default:
             $transport = $this->getSendMailTransport();

--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -7,7 +7,7 @@ namespace Crunz;
 use Crunz\Configuration\Configuration;
 use Crunz\Exception\MailerException;
 
-class Mailer
+final class Mailer
 {
     /** @var \Swift_Mailer|null */
     protected $mailer;
@@ -22,10 +22,9 @@ class Mailer
     /**
      * Send an email.
      *
-     * @param string $subject
-     * @param string $message
+     * @throws MailerException
      */
-    public function send($subject, $message): void
+    public function send(string $subject, string $message): void
     {
         $this->getMailer()
             ->send(
@@ -37,9 +36,9 @@ class Mailer
     /**
      * Return the proper mailer.
      *
-     * @return \Swift_Mailer
+     * @throws MailerException
      */
-    protected function getMailer()
+    private function getMailer(): \Swift_Mailer
     {
         // If the mailer has already been defined via the constructor, return it.
         if ($this->mailer) {
@@ -49,8 +48,9 @@ class Mailer
         // Get the proper transporter
         switch ($this->config('mailer.transport')) {
             case 'smtp':
-            $transport = $this->getSmtpTransport();
-            break;
+                $transport = $this->getSmtpTransport();
+
+                break;
 
             case 'mail':
                 throw new MailerException(
@@ -60,88 +60,51 @@ class Mailer
                 break;
 
             default:
-            $transport = $this->getSendMailTransport();
+                $transport = $this->getSendMailTransport();
         }
 
-        $this->mailer = \method_exists(\Swift_Mailer::class, 'newInstance')
-            ? \Swift_Mailer::newInstance($transport)
-            : new \Swift_Mailer($transport)
-        ;
+        $this->mailer = new \Swift_Mailer($transport);
 
         return $this->mailer;
     }
 
     /**
      * Get the SMTP transport.
-     *
-     * @return \Swift_SmtpTransport
      */
-    protected function getSmtpTransport()
+    private function getSmtpTransport(): \Swift_SmtpTransport
     {
-        $object = \method_exists(\Swift_SmtpTransport::class, 'newInstance')
-            ? \Swift_SmtpTransport::newInstance(
-                $this->config('smtp.host'),
-                $this->config('smtp.port'),
-                $this->config('smtp.encryption')
-            )
-            : new \Swift_SmtpTransport(
-                $this->config('smtp.host'),
-                $this->config('smtp.port'),
-                $this->config('smtp.encryption')
-            );
+        $object = new \Swift_SmtpTransport(
+            $this->config('smtp.host'),
+            $this->config('smtp.port'),
+            $this->config('smtp.encryption')
+        );
 
         return $object
-        ->setUsername($this->config('smtp.username'))
-        ->setPassword($this->config('smtp.password'));
-    }
-
-    /**
-     * Get the Mail transport.
-     *
-     * @return \Swift_MailTransport
-     */
-    protected function getMailTransport()
-    {
-        if (!\class_exists('\Swift_MailTransport')) {
-            throw new \Exception('Mail transport has been removed in SwiftMailer 6');
-        }
-
-        return \Swift_MailTransport::newInstance();
+            ->setUsername($this->config('smtp.username'))
+            ->setPassword($this->config('smtp.password'))
+        ;
     }
 
     /**
      * Get the Sendmail Transport.
-     *
-     * @return \Swift_SendmailTransport
      */
-    protected function getSendMailTransport()
+    private function getSendMailTransport(): \Swift_SendmailTransport
     {
-        return \method_exists(\Swift_SendmailTransport::class, 'newInstance')
-            ? \Swift_SendmailTransport::newInstance()
-            : new \Swift_SendmailTransport();
+        return new \Swift_SendmailTransport();
     }
 
     /**
      * Prepare a swift message object.
-     *
-     * @param string $subject
-     * @param string $message
-     *
-     * @return \Swift_Message
      */
-    protected function getMessage($subject, $message)
+    private function getMessage(string $subject, string $message): \Swift_Message
     {
-        $object = \method_exists(\Swift_Message::class, 'newInstance')
-            ? \Swift_Message::newInstance($subject, $message)
-            : new \Swift_Message($subject, $message)
-        ;
-
-        $object
+        $messageObject = new \Swift_Message($subject, $message);
+        $messageObject
             ->setFrom([$this->config('mailer.sender_email') => $this->config('mailer.sender_name')])
             ->setTo($this->config('mailer.recipients'))
         ;
 
-        return $object;
+        return $messageObject;
     }
 
     private function config($key)

--- a/tests/Unit/MailerTest.php
+++ b/tests/Unit/MailerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\Unit;
+
+use Crunz\Configuration\Configuration;
+use Crunz\Exception\MailerException;
+use Crunz\Mailer;
+use PHPUnit\Framework\TestCase;
+
+final class MailerTest extends TestCase
+{
+    /** @test */
+    public function usingMailTransportWillResultInException(): void
+    {
+        $this->expectException(MailerException::class);
+        $this->expectExceptionMessage("'mail' transport is no longer supported, please use 'smtp' or 'sendmail' transport.");
+
+        $mailer = $this->createMailer('mail');
+        $mailer->send('Test', 'Message');
+    }
+
+    private function createMailer(string $transport): Mailer
+    {
+        $configurationMock = $this->createMock(Configuration::class);
+        $configurationMock
+            ->method('get')
+            ->with('mailer.transport')
+            ->willReturn($transport)
+        ;
+
+        return new Mailer($configurationMock);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | no

SwiftMailer `v6` do not support `mail` transport, so `Crunz` `v2.0` won't support it either.
