### PR TITLE
Fix recursive tasks scan

### DIFF
--- a/src/Filesystem/Filesystem.php
+++ b/src/Filesystem/Filesystem.php
@@ -73,6 +73,9 @@ final class Filesystem implements FilesystemInterface
     /** {@inheritdoc} */
     public function dumpFile($filePath, $content)
     {
+        $directory = \pathinfo($filePath, \PATHINFO_DIRNAME);
+        $this->createDirectory($directory);
+
         \file_put_contents($filePath, $content);
     }
 

--- a/src/Finder/Finder.php
+++ b/src/Finder/Finder.php
@@ -9,14 +9,26 @@ final class Finder implements FinderInterface
     /**
      * {@inheritdoc}
      */
-    public function find(Path $path)
+    public function find(Path $directory, $suffix)
     {
-        /** @var \SplFileInfo[] $globIterator */
-        $globIterator = new \GlobIterator(
-            $path->toString(),
-            \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::SKIP_DOTS
+        $quotedSuffix = \preg_quote($suffix, '/');
+        $directoryIterator = new \RecursiveDirectoryIterator($directory->toString());
+        $recursiveIterator = new \RecursiveIteratorIterator($directoryIterator);
+
+        $regexIterator = new \RegexIterator(
+            $recursiveIterator,
+            "/^.+{$quotedSuffix}$/i",
+            \RecursiveRegexIterator::GET_MATCH
         );
 
-        return $globIterator;
+        /** @var \SplFileInfo[] $files */
+        $files = \array_map(
+            static function (array $file) {
+                return new \SplFileInfo(\reset($file));
+            },
+            \iterator_to_array($regexIterator)
+        );
+
+        return $files;
     }
 }

--- a/src/Finder/FinderInterface.php
+++ b/src/Finder/FinderInterface.php
@@ -6,6 +6,10 @@ use Crunz\Path\Path;
 
 interface FinderInterface
 {
-    /** @return \SplFileInfo[] */
-    public function find(Path $path);
+    /**
+     * @param string $suffix
+     *
+     * @return \SplFileInfo[]
+     */
+    public function find(Path $directory, $suffix);
 }

--- a/src/Task/Collection.php
+++ b/src/Task/Collection.php
@@ -43,12 +43,9 @@ class Collection
         $suffix = $this->configuration
             ->get('suffix')
         ;
-        $sourcePath = Path::create(
-            [
-                $source,
-                "*{$suffix}",
-            ]
-        );
+
+        $this->consoleLogger
+            ->debug("Task finder suffix: '<info>{$suffix}</info>'");
 
         $realPath = \realpath($source);
         if (false !== $realPath) {
@@ -59,11 +56,8 @@ class Collection
                 ->verbose("Realpath resolve for '<info>{$source}</info>' failed.");
         }
 
-        $this->consoleLogger
-            ->debug("Task finder pattern '<info>{$sourcePath->toString()}</info>'");
-
         $tasks = $this->finder
-            ->find($sourcePath)
+            ->find(Path::fromStrings($source), $suffix)
         ;
         $tasksCount = \count($tasks);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | https://github.com/lavary/crunz/issues/228

This PR will bring back recursive tasks' directory scanning, which was removed by accident.
