### PR TITLE
Add option to ignore empty context in monolog

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,10 @@ output_log_file:
 # Set the value to true to allow them.
 log_allow_line_breaks: false
 
+# By default empty context arrays are shown in the log.
+# Set the value to true to remove them.
+log_ignore_empty_context: false
+
 # This option determines whether the output should be emailed or not.
 email_output: false
 

--- a/resources/config/crunz.yml
+++ b/resources/config/crunz.yml
@@ -43,6 +43,10 @@ output_log_file: ~
 # Set the value to true to allow them.
 log_allow_line_breaks: false
 
+# By default empty context arrays are shown in the log.
+# Set the value to true to remove them.
+log_ignore_empty_context: false
+
 # This option determines whether the output should be emailed or not.
 email_output: false
 

--- a/src/Configuration/Definition.php
+++ b/src/Configuration/Definition.php
@@ -68,6 +68,11 @@ class Definition implements ConfigurationInterface
                     ->info('Flag for line breaks in logs' . PHP_EOL)
                 ->end()
 
+                ->scalarNode('log_ignore_empty_context')
+                    ->defaultFalse()
+                    ->info('Flag for empty context in logs' . PHP_EOL)
+                ->end()
+
                 ->scalarNode('email_output')
                     ->defaultFalse()
                     ->info('Email the event\'s output' . PHP_EOL)

--- a/src/Logger/Logger.php
+++ b/src/Logger/Logger.php
@@ -116,11 +116,15 @@ class Logger
             ->get('log_allow_line_breaks')
         ;
 
+        $ignoreEmptyContext = $this->configuration
+            ->get('log_ignore_empty_context')
+        ;
+
         return new LineFormatter(
             null,
             null,
             $allowLinebreaks,
-            false
+            $ignoreEmptyContext
         );
     }
 

--- a/tests/crunz.yml
+++ b/tests/crunz.yml
@@ -7,6 +7,7 @@ errors_log_file: ~
 log_output: false
 output_log_file: ~
 log_allow_line_breaks: false
+log_ignore_empty_context: false
 email_output: false
 email_errors: false
 mailer:


### PR DESCRIPTION
Added the option to allow ignoring of empty context when writing to monolog. I reason for this is to slim down the number of lines the logging produces and the double [] [] monolog is writing does not need to be there.
