### PR TITLE
Don't log to main log file if event has its own log file set.

### DIFF
--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -239,7 +239,7 @@ class EventRunner
             $event->logger->info($this->formatEventOutput($event));
             $logged = true;
         }
-        
+
         if ($logOutput && !$logged) {
             $this->logger->info($this->formatEventOutput($event));
             $logged = true;

--- a/src/EventRunner.php
+++ b/src/EventRunner.php
@@ -235,14 +235,16 @@ class EventRunner
             ->get('log_output')
         ;
 
-        if ($logOutput) {
-            $this->logger->info($this->formatEventOutput($event));
-            $logged = true;
-        }
         if (!$event->nullOutput()) {
             $event->logger->info($this->formatEventOutput($event));
             $logged = true;
         }
+        
+        if ($logOutput && !$logged) {
+            $this->logger->info($this->formatEventOutput($event));
+            $logged = true;
+        }
+
         if (!$logged) {
             $this->display($event->getOutputStream());
         }


### PR DESCRIPTION
In the crunz.yml file it states this:

>  The events which have dedicated log files (defined with them), won't be
>  logged to this file though.

This is currently not happening and it is logging to both files. This PR is to fix this and only log to the main log file if the event does not have a log file set.
