### PR TITLE
Swap out the cron-expression package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     },
     "require": {
         "php": "^7.2",
+        "dragonmantank/cron-expression": "^2.3",
         "jeremeamia/superclosure": "^2.2",
         "monolog/monolog": "^1.19",
-        "mtdowling/cron-expression": "^1.1",
         "nikic/php-parser": "^3.0 || ^4.0",
         "swiftmailer/swiftmailer": "^6.0",
         "symfony/config": "^3.4 || ^4.2",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "require": {
         "php": "^7.2",
-        "dragonmantank/cron-expression": "^2.3",
+        "dragonmantank/cron-expression": "^2.0",
         "jeremeamia/superclosure": "^2.2",
         "monolog/monolog": "^1.19",
         "nikic/php-parser": "^3.0 || ^4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #239   <!-- #-prefixed issue number(s), if any -->

`mtdowling/cron-expression` has been deprecated in favor of `dragonmantank/cron-expression` according to the [README](https://github.com/mtdowling/cron-expression). This PR replaces the deprecated `cron-expression` package for a maintained fork.

Implementation notes
--------------------

Seems to be a drop-in replacement. 

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
