### PR TITLE
Sandbox task loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - [#244] Fix AppVeyor CI
+- [#243] Sandbox task loading
 
 ## [v1.12.1] - 2019-05-01
 
@@ -184,8 +185,8 @@ In `v2` this will result in exception.
 
 - [#77] Fix high cpu usage
 
-
 [#244]: https://github.com/lavary/crunz/pull/244
+[#243]: https://github.com/lavary/crunz/pull/243
 [#229]: https://github.com/lavary/crunz/pull/229
 [#217]: https://github.com/lavary/crunz/pull/217
 [#210]: https://github.com/lavary/crunz/pull/210

--- a/config/services.php
+++ b/config/services.php
@@ -94,6 +94,7 @@ $container
         [
             new Reference(Configuration::class),
             new Reference(Collection::class),
+            new Reference(LoaderInterface::class),
         ]
     )
 ;

--- a/config/services.php
+++ b/config/services.php
@@ -68,6 +68,7 @@ $container
             new Reference(EventRunner::class),
             new Reference(Timezone::class),
             new Reference(ScheduleFactory::class),
+            new Reference(LoaderInterface::class),
         ]
     )
 ;

--- a/config/services.php
+++ b/config/services.php
@@ -28,6 +28,8 @@ use Crunz\Mailer;
 use Crunz\Output\OutputFactory;
 use Crunz\Schedule\ScheduleFactory;
 use Crunz\Task\Collection;
+use Crunz\Task\Loader;
+use Crunz\Task\LoaderInterface;
 use Crunz\Task\Timezone;
 use Crunz\Timezone\Provider;
 use Crunz\Timezone\ProviderInterface;
@@ -53,6 +55,7 @@ $simpleServices = [
     CurlHttpClient::class,
     FilesystemInterface::class => CrunzFilesystem::class,
     FinderInterface::class => Finder::class,
+    LoaderInterface::class => Loader::class,
 ];
 
 $container

--- a/src/Console/Command/ScheduleRunCommand.php
+++ b/src/Console/Command/ScheduleRunCommand.php
@@ -16,12 +16,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ScheduleRunCommand extends Command
 {
-    /**
-     * Running tasks.
-     *
-     * @var array
-     */
-    protected $runningEvents = [];
     /** @var Collection */
     private $taskCollection;
     /** @var Configuration */

--- a/src/Task/Loader.php
+++ b/src/Task/Loader.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Crunz\Task;
+
+use Crunz\Schedule;
+
+final class Loader implements LoaderInterface
+{
+    /** @return Schedule[] */
+    public function load(\SplFileInfo ...$files)
+    {
+        $schedules = [];
+        foreach ($files as $file) {
+            /**
+             * Actual "require" is in separated method to make sure
+             * local variables are not overwritten by required file
+             * See: https://github.com/lavary/crunz/issues/242 for more information.
+             */
+            $schedule = $this->loadSchedule($file);
+            if (!$schedule instanceof Schedule) {
+                // @TODO throw exception in v2
+                @\trigger_error(
+                    "File '{$file->getRealPath()}' didn't return '\Crunz\Schedule' instance, this behavior is deprecated since v1.12 and will result in exception in v2.0+",
+                    E_USER_DEPRECATED
+                );
+
+                continue;
+            }
+
+            $schedules[] = $schedule;
+        }
+
+        return $schedules;
+    }
+
+    /** @return Schedule */
+    private function loadSchedule(\SplFileInfo $file)
+    {
+        return require $file->getRealPath();
+    }
+}

--- a/src/Task/LoaderInterface.php
+++ b/src/Task/LoaderInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Crunz\Task;
+
+use Crunz\Schedule;
+
+interface LoaderInterface
+{
+    /** @return Schedule[] */
+    public function load(\SplFileInfo ...$files);
+}

--- a/tests/Unit/Console/Command/ScheduleRunCommandTest.php
+++ b/tests/Unit/Console/Command/ScheduleRunCommandTest.php
@@ -8,6 +8,7 @@ use Crunz\Event;
 use Crunz\EventRunner;
 use Crunz\Schedule;
 use Crunz\Task\Collection;
+use Crunz\Task\Loader;
 use Crunz\Task\Timezone;
 use Crunz\Tests\TestCase\TemporaryFile;
 use PHPUnit\Framework\TestCase;
@@ -33,7 +34,8 @@ class ScheduleRunCommandTest extends TestCase
             $this->createMock(Configuration::class),
             $mockEventRunner,
             $this->createMock(Timezone::class),
-            $this->createMock(Schedule\ScheduleFactory::class)
+            $this->createMock(Schedule\ScheduleFactory::class),
+            $this->createTaskLoader()
         );
 
         $command->run(
@@ -60,7 +62,8 @@ class ScheduleRunCommandTest extends TestCase
             $this->createMock(Configuration::class),
             $mockEventRunner,
             $this->mockTimezoneProvider(),
-            $this->mockScheduleFactory()
+            $this->mockScheduleFactory(),
+            $this->createTaskLoader()
         );
 
         $command->run(
@@ -198,5 +201,10 @@ $schedule->run('php -v')
 
 return $schedule;
 PHP;
+    }
+
+    private function createTaskLoader()
+    {
+        return new Loader();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #242    <!-- #-prefixed issue number(s), if any -->

This PR fixes #242 by introducing `\Crunz\Task\LoaderInterface` and `require`ing files in separate, private, method to avoid variables overriding.
