### PR TITLE
Fix AppVeyor CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- [#244] Fix AppVeyor CI
+
 ## [v1.12.1] - 2019-05-01
 
 ### Fixed
@@ -181,6 +185,7 @@ In `v2` this will result in exception.
 - [#77] Fix high cpu usage
 
 
+[#244]: https://github.com/lavary/crunz/pull/244
 [#229]: https://github.com/lavary/crunz/pull/229
 [#217]: https://github.com/lavary/crunz/pull/217
 [#210]: https://github.com/lavary/crunz/pull/210

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,8 +34,8 @@ install:
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
     - cd c:\projects\crunz
-    - IF %dependencies%==low appveyor-retry composer update --prefer-lowest --no-progress -n
-    - IF %dependencies%==high appveyor-retry composer update --no-progress -n
+    - IF %dependencies%==low appveyor-retry composer update --prefer-lowest --no-progress -n --no-suggest
+    - IF %dependencies%==high appveyor-retry composer update --no-progress -n --no-suggest
     - appveyor-retry composer bin phpunit install -a --no-progress
     - composer show
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,8 +34,8 @@ install:
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
     - cd c:\projects\crunz
-    - IF %dependencies%==low appveyor-retry composer update --prefer-lowest --no-progress --profile -n
-    - IF %dependencies%==high appveyor-retry composer update --no-progress --profile -n
+    - IF %dependencies%==low appveyor-retry composer update --prefer-lowest --no-progress -n
+    - IF %dependencies%==high appveyor-retry composer update --no-progress -n
     - appveyor-retry composer bin phpunit install -a --no-progress
     - composer show
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ environment:
         - dependencies: high
           php_ver_target: 5.6.40
         - dependencies: low
-          php_ver_target: 7.2
+          php_ver_target: 7.3.9
         - dependencies: high
-          php_ver_target: 7.2
+          php_ver_target: 7.3.9
 
 init:
     - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ init:
 
 install:
     - IF EXIST c:\tools\php (SET PHP=0) # Checks for the PHP install being cached
-    - ps: appveyor-retry choco install php --version $env:php_ver_target -y --package-parameters='"/InstallDir:C:\tools\php"'
+    - ps: appveyor-retry choco install php --version $env:php_ver_target -y --no-progress --package-parameters='"/InstallDir:C:\tools\php"'
     - cd c:\tools\php
     - IF %PHP%==1 copy php.ini-production php.ini /Y
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,9 @@ clone_folder: c:\projects\crunz
 environment:
     matrix:
         - dependencies: low
-          php_ver_target: 5.6
+          php_ver_target: 5.6.40
         - dependencies: high
-          php_ver_target: 5.6
+          php_ver_target: 5.6.40
         - dependencies: low
           php_ver_target: 7.2
         - dependencies: high

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ init:
 
 install:
     - IF EXIST c:\tools\php (SET PHP=0) # Checks for the PHP install being cached
-    - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+    - ps: appveyor-retry choco install php --version $env:php_ver_target -y
     - cd c:\tools\php
     - IF %PHP%==1 copy php.ini-production php.ini /Y
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ init:
 
 install:
     - IF EXIST c:\tools\php (SET PHP=0) # Checks for the PHP install being cached
-    - ps: appveyor-retry choco install php --version $env:php_ver_target -y
+    - ps: appveyor-retry choco install php --version $env:php_ver_target -y --package-parameters='"/InstallDir:C:\tools\php"'
     - cd c:\tools\php
     - IF %PHP%==1 copy php.ini-production php.ini /Y
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | no

For some reason `cinst` is no longer available in AppVeyor CI.
