### PR TITLE
Revert converting closure result to int

### DIFF
--- a/src/Console/Command/ClosureRunCommand.php
+++ b/src/Console/Command/ClosureRunCommand.php
@@ -33,6 +33,8 @@ class ClosureRunCommand extends Command
         \parse_str($this->arguments['closure'], $args);
         $serializer = new Serializer();
 
-        return (int) !((bool) \call_user_func_array($serializer->unserialize($args[0]), []));
+        \call_user_func_array($serializer->unserialize($args[0]), []);
+
+        return 0;
     }
 }

--- a/tests/Unit/Console/Command/ClosureRunCommandTest.php
+++ b/tests/Unit/Console/Command/ClosureRunCommandTest.php
@@ -12,10 +12,11 @@ use Symfony\Component\Console\Output\NullOutput;
 
 final class ClosureRunCommandTest extends TestCase
 {
-    public function testReturnValueOfClosureIsOmitted(): void
+    /** @dataProvider closureValueProvider */
+    public function testReturnValueOfClosureIsOmitted(int $returnValue): void
     {
-        $closure = static function (): int {
-            return 0;
+        $closure = static function () use ($returnValue): int {
+            return $returnValue;
         };
         $command = new ClosureRunCommand();
         $input = $this->createInput($closure);
@@ -25,6 +26,12 @@ final class ClosureRunCommandTest extends TestCase
             0,
             $command->run($input, $output)
         );
+    }
+
+    public function closureValueProvider(): iterable
+    {
+        yield '0' => [0];
+        yield '1' => [1];
     }
 
     private function createInput(\Closure $closure): ArrayInput

--- a/tests/Unit/Console/Command/ClosureRunCommandTest.php
+++ b/tests/Unit/Console/Command/ClosureRunCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Crunz\Tests\Unit\Console\Command;
+
+use Crunz\Console\Command\ClosureRunCommand;
+use PHPUnit\Framework\TestCase;
+use SuperClosure\Serializer;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+final class ClosureRunCommandTest extends TestCase
+{
+    public function testReturnValueOfClosureIsOmitted(): void
+    {
+        $closure = static function (): int {
+            return 0;
+        };
+        $command = new ClosureRunCommand();
+        $input = $this->createInput($closure);
+        $output = new NullOutput();
+
+        $this->assertSame(
+            0,
+            $command->run($input, $output)
+        );
+    }
+
+    private function createInput(\Closure $closure): ArrayInput
+    {
+        $closureSerializer = new Serializer();
+
+        return new ArrayInput(
+            [
+                'closure' => \http_build_query(
+                    [
+                        $closureSerializer->serialize($closure),
+                    ]
+                ),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #260 

Unintended (not documented) BC break was introduced in https://github.com/lavary/crunz/commit/9c9cf9db141594547285f9d5af4ca48d2856891a#diff-99156d24102de67b9de59f1792622c62R36, Closures that were fine in `v1.x` starts to fail in `v2.x`, because they do not return any value.
This PR reverts BC-break change, so behavior will be consistent for `v1.x` and `v2.x`