### PR TITLE
Add no-constraint option

### DIFF
--- a/src/Console/Command/TaskGeneratorCommand.php
+++ b/src/Console/Command/TaskGeneratorCommand.php
@@ -23,6 +23,7 @@ class TaskGeneratorCommand extends Command
     const DEFAULTS = [
         'frequency' => 'everyThirtyMinutes',
         'constraint' => 'weekdays',
+        'no-constraint' => false,
         'in' => 'path/to/your/command',
         'run' => 'command/to/execute',
         'description' => 'Task description',
@@ -75,6 +76,13 @@ class TaskGeneratorCommand extends Command
                         InputOption::VALUE_OPTIONAL,
                         "The task's constraint",
                         self::DEFAULTS['constraint']
+                    ),
+                    new InputOption(
+                        'no-constraint',
+                        'nc',
+                        InputOption::VALUE_OPTIONAL,
+                        "Remove constraint from task",
+                        self::DEFAULTS['no-constraint']
                     ),
                     new InputOption(
                         'in',
@@ -248,7 +256,20 @@ class TaskGeneratorCommand extends Command
      */
     protected function replaceConstraint(): self
     {
-        $this->stub = \str_replace('DummyConstraint', \rtrim($this->options['constraint'], '()'), $this->stub);
+
+        if ($this->getNoConstraint() === false) {
+            $this->stub = \str_replace(
+                'DummyConstraint', 
+                \rtrim($this->options['constraint'], '()'), 
+                $this->stub
+            );
+        } else {
+            $this->stub = \preg_replace(
+                "/^[\s\t]{0,}->DummyConstraint\(\)\n/m", 
+                "", 
+                $this->stub
+            );
+        }
 
         return $this;
     }
@@ -282,4 +303,21 @@ class TaskGeneratorCommand extends Command
 
         return $this;
     }
+
+    /**
+     * Return single value for no-constraint option
+     */
+    protected function getNoConstraint()
+    {
+        // for stylistic purposes providing "--no-constraint" returns true
+        if ($this->options['no-constraint'] === null) {
+            return true;
+        }
+
+        return filter_var(
+            $this->options['no-constraint'], 
+            FILTER_VALIDATE_BOOLEAN
+        );
+    }
 }
+


### PR DESCRIPTION
make:task --constraint default to 'weekdays'. If one does not want a constraint at all, for example if they want it to run every day, there was no way to do this since the code in replaceConstraint simply replaces DummyConstraint with whatever is provided.  The documentation didn't 

This commit adds an option, "no-constraint", that defaults to "false" and can be provided as true/false, yes/no, 1/0 or can be simply provided as --no-constraint. When this flag is true the DummyConstraint line is removed from the output task file. 

The `constraint` default value of 'weekdays' was left in place for backward compatibility.

For example:

Default behavior:
`crunz make:task -r ls -f daily mytask`
<img width="314" alt="Screen Shot 2020-03-23 at 3 41 32 PM" src="https://user-images.githubusercontent.com/41806231/77361228-ef541b80-6d1c-11ea-96d5-c51cdd48f12c.png">

Providing anything ("none") for constraint:
`crunz make:task -r ls -f daily -c none mytask`
<img width="309" alt="Screen Shot 2020-03-23 at 3 42 24 PM" src="https://user-images.githubusercontent.com/41806231/77361362-232f4100-6d1d-11ea-890b-10eea3aa2de9.png">

After this commit, `--no-constraint`:
`crunz make:task -r ls -f daily --no-constraint mytask`
<img width="305" alt="Screen Shot 2020-03-23 at 3 41 23 PM" src="https://user-images.githubusercontent.com/41806231/77361566-828d5100-6d1d-11ea-8e22-ee0ce48849ea.png">

The tests for the task generator don't check the contents of the file, so I didn't add tests for this specific case. 