### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [v2.2.0] - 2020-06-18
+
+### Added
+
+- [#287] Add `task:debug` command
+- [#233] Add option to ignore empty context in monolog, thanks to [@rrushton]
+- [#298] Add `logger_factory` config option
+
+### Removed
+
+- [#292] Drop Symfony 4.2 support
+
 ## [v2.1.0] - 2020-02-02
 
 ### Added
@@ -251,6 +263,9 @@ In `v2` this will result in exception.
 
 - [#77] Fix high cpu usage
 
+[#298]: https://github.com/lavary/crunz/pull/298
+[#292]: https://github.com/lavary/crunz/pull/292
+[#287]: https://github.com/lavary/crunz/pull/287
 [#280]: https://github.com/lavary/crunz/pull/280
 [#274]: https://github.com/lavary/crunz/pull/274
 [#268]: https://github.com/lavary/crunz/pull/268
@@ -260,6 +275,7 @@ In `v2` this will result in exception.
 [#245]: https://github.com/lavary/crunz/pull/245
 [#243]: https://github.com/lavary/crunz/pull/243
 [#240]: https://github.com/lavary/crunz/pull/240
+[#233]: https://github.com/lavary/crunz/pull/233
 [#229]: https://github.com/lavary/crunz/pull/229
 [#225]: https://github.com/lavary/crunz/pull/225
 [#224]: https://github.com/lavary/crunz/pull/224
@@ -385,6 +401,7 @@ In `v2` this will result in exception.
 [v2.0.3]: https://github.com/lavary/crunz/compare/v2.0.2...v2.0.3
 [v2.0.4]: https://github.com/lavary/crunz/compare/v2.0.3...v2.0.4
 [v2.1.0]: https://github.com/lavary/crunz/compare/v2.0.4...v2.1.0
+[v2.2.0]: https://github.com/lavary/crunz/compare/v2.1.0...v2.2.0
 [@vinkla]: https://github.com/vinkla
 [@timurbakarov]: https://github.com/timurbakarov
 [@radarhere]: https://github.com/radarhere
@@ -401,3 +418,4 @@ In `v2` this will result in exception.
 [@FallDi]: https://github.com/FallDi
 [@SadeghPM]: https://github.com/SadeghPM
 [@mareksuscak]: https://github.com/mareksuscak
+[@rrushton]: https://github.com/rrushton

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Crunz is capable of executing any kind of executable command as well as PHP clos
 
 |Version|Supported PHP versions|Linux build|Windows build|
 |---|---|---|---|
-|stable (v2.1.0)|![7.2+](https://img.shields.io/badge/php-%5E7.2-blue.svg?style=flat-square)|[![Build Status](https://img.shields.io/travis/lavary/crunz/v2.1.0.svg?style=flat-square)](https://travis-ci.org/lavary/crunz)|*Tag build not supported*
+|stable (v2.2.0)|![7.2+](https://img.shields.io/badge/php-%5E7.2-blue.svg?style=flat-square)|[![Build Status](https://img.shields.io/travis/lavary/crunz/v2.2.0.svg?style=flat-square)](https://travis-ci.org/lavary/crunz)|*Tag build not supported*
 |dev v2 (master/v2.x-dev)|![7.2+](https://img.shields.io/badge/php-%5E7.2-blue.svg?style=flat-square)|[![Build Status](https://img.shields.io/travis/lavary/crunz/master.svg?style=flat-square)](https://travis-ci.org/lavary/crunz)|[![AppVeyor branch](https://img.shields.io/appveyor/ci/lavary/crunz/master.svg?style=flat-square)](https://ci.appveyor.com/project/lavary/crunz)
 |dev v1.12.x (v1.12.x-dev)|![5.6+](https://img.shields.io/badge/php-%5E5.6%20%7C%7C%20%5E7.0-blue.svg?style=flat-square)|[![Build Status](https://img.shields.io/travis/lavary/crunz/1.12.x.svg?style=flat-square)](https://travis-ci.org/lavary/crunz)|[![AppVeyor branch](https://img.shields.io/appveyor/ci/lavary/crunz/1.12.x.svg?style=flat-square)](https://ci.appveyor.com/project/lavary/crunz)
 

--- a/composer.json
+++ b/composer.json
@@ -76,8 +76,7 @@
     "extra": {
         "branch-alias": {
             "dev-master": "2.x-dev",
-            "dev-2.1.x": "v2.1.x-dev",
-            "dev-1.12.x": "1.12.x-dev"
+            "dev-2.2.x": "v2.2.x-dev"
         }
     }
 }

--- a/crunz
+++ b/crunz
@@ -67,5 +67,5 @@ if ($autoloadFileFound === false) {
     );
 }
 
-$application = new Crunz\Application('Crunz Command Line Interface', 'v2.2.x-dev');
+$application = new Crunz\Application('Crunz Command Line Interface', 'v2.2.0');
 $application->run();


### PR DESCRIPTION
## PRs

- [#287] Add `task:debug` command
- [#288] Improve TravisCI configuration
- [#290] Remove "dev_tools" service from docker-compose
- [#291] Remove box from vendor bin
- [#292] Drop Symfony 4.2 support
- [#294] Update docs for Symfony 5 locking, thanks to @hashnz
- [#233] Add option to ignore empty context in monolog
- [#297] Add ConfigurationInterface
- [#299] Migrate to `opis\closure`
- [#300] Update dev tools
- [#298] Implement logger factory rfc
- [#304] Add "status" column to roadmap
- [#305] Test Symfony 5.1 compatibility