### PR TITLE
Add quotes around path in case of spaces.

### DIFF
--- a/crunz
+++ b/crunz
@@ -67,5 +67,5 @@ if ($autoloadFileFound === false) {
     );
 }
 
-$application = new Crunz\Application('Crunz Command Line Interface', 'v2.2.0');
+$application = new Crunz\Application('Crunz Command Line Interface', 'v2.3.x-dev');
 $application->run();

--- a/src/Event.php
+++ b/src/Event.php
@@ -1110,8 +1110,12 @@ class Event implements PingableInterface
         $closure = (new OpisClosureSerializer())->serialize($closure);
         $serializedClosure = \http_build_query([$closure]);
         $crunzRoot = CRUNZ_BIN;
-
-        return PHP_BINARY . " {$crunzRoot} closure:run {$serializedClosure}";
+        $phpBin = PHP_BINARY;
+        if (DIRECTORY_SEPARATOR === '\\') {
+            // For Windows, add quotes around path in case of spaces.
+            $phpBin = '"'.$phpBin.'"';
+        }
+        return "{$phpBin} {$crunzRoot} closure:run {$serializedClosure}";
     }
 
     /**

--- a/tests/Unit/EventTest.php
+++ b/tests/Unit/EventTest.php
@@ -346,7 +346,12 @@ final class EventTest extends UnitTestCase
         if (!\defined('CRUNZ_BIN')) {
             \define('CRUNZ_BIN', __FILE__);
         }
-
+        
+        $phpBin = PHP_BINARY;
+        if ($this->isWindows()) {
+            $phpBin = '"'.$phpBin.'"';
+        }
+        
         $closure = function () {
             return 0;
         };
@@ -359,7 +364,7 @@ final class EventTest extends UnitTestCase
 
         $command = $event->buildCommand();
 
-        $this->assertSame(PHP_BINARY . " {$crunzBin} closure:run {$queryClosure}", $command);
+        $this->assertSame("{$phpBin} {$crunzBin} closure:run {$queryClosure}", $command);
     }
 
     /** @test */


### PR DESCRIPTION
For Windows, add quotes around path in case of spaces.