### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [v2.3.0] - 2021-03-14
+
+### Deprecated
+
+- [#344] Deprecate most "Event::every*" methods
+
+### Removed
+
+- [#323] Drop Symfony 4.3 support
+- [#324] Drop Symfony 5.0 support
+
 ## [v2.2.4] - 2020-12-18
 
 ### Fixed
@@ -287,9 +298,12 @@ In `v2` this will result in exception.
 
 - [#77] Fix high cpu usage
 
+[#344]: https://github.com/lavary/crunz/pull/344
 [#334]: https://github.com/lavary/crunz/pull/334
 [#333]: https://github.com/lavary/crunz/pull/333
 [#326]: https://github.com/lavary/crunz/pull/326
+[#324]: https://github.com/lavary/crunz/pull/324
+[#323]: https://github.com/lavary/crunz/pull/323
 [#321]: https://github.com/lavary/crunz/pull/321
 [#298]: https://github.com/lavary/crunz/pull/298
 [#292]: https://github.com/lavary/crunz/pull/292
@@ -434,6 +448,7 @@ In `v2` this will result in exception.
 [v2.2.2]: https://github.com/lavary/crunz/compare/v2.2.1...v2.2.2
 [v2.2.3]: https://github.com/lavary/crunz/compare/v2.2.2...v2.2.3
 [v2.2.4]: https://github.com/lavary/crunz/compare/v2.2.3...v2.2.4
+[v2.3.0]: https://github.com/lavary/crunz/compare/v2.2.4...v2.3.0
 [@vinkla]: https://github.com/vinkla
 [@timurbakarov]: https://github.com/timurbakarov
 [@radarhere]: https://github.com/radarhere

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Crunz is capable of executing any kind of executable command as well as PHP clos
 
 |Version|Supported PHP versions|Windows build|
 |---|---|---|
-|stable (v2.2.4)|![7.2+](https://img.shields.io/badge/php-%3E=7.2-blue.svg?style=flat-square)|*Tag build not supported*
+|stable (v2.3.0)|![7.2+](https://img.shields.io/badge/php-%3E=7.2-blue.svg?style=flat-square)|*Tag build not supported*
 |dev v2 (master/v2.x-dev)|![7.2+](https://img.shields.io/badge/php-%3E=7.2-blue.svg?style=flat-square)|[![AppVeyor branch](https://img.shields.io/appveyor/ci/lavary/crunz/master.svg?style=flat-square)](https://ci.appveyor.com/project/lavary/crunz)
 |dev v1.12.x (v1.12.x-dev)|![5.6+](https://img.shields.io/badge/php-%5E5.6%20%7C%7C%20%5E7.0-blue.svg?style=flat-square)|[![AppVeyor branch](https://img.shields.io/appveyor/ci/lavary/crunz/1.12.x.svg?style=flat-square)](https://ci.appveyor.com/project/lavary/crunz)
 

--- a/crunz
+++ b/crunz
@@ -67,5 +67,5 @@ if ($autoloadFileFound === false) {
     );
 }
 
-$application = new Crunz\Application('Crunz Command Line Interface', 'v2.3.x-dev');
+$application = new Crunz\Application('Crunz Command Line Interface', 'v2.3.0');
 $application->run();


### PR DESCRIPTION
## PRs

- [#323] Drop Symfony 4.3 support
- [#324] Drop Symfony 5.0 support
- [#335] Add "code_checks" workflow
- [#336] Fix missing "composer version" command in CI
- [#337] Fix dependencies versions in "static_analysis" job
- [#338] Do not test PHP v8.1
- [#344] Deprecate most "Event::every*" methods
- [#347] Update dev dependencies