### PR TITLE
Add bootstrap for closures

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -94,6 +94,7 @@ $container
     ->setArguments(
         [
             new Reference(ClosureSerializerInterface::class),
+            new Reference(ConfigurationInterface::class),
         ]
     )
     ->setPublic(true)

--- a/resources/config/crunz.yml
+++ b/resources/config/crunz.yml
@@ -1,5 +1,9 @@
 # Crunz Configuration Settings
 
+# A file to include before closure functions are run.
+# For example include your autoloader.
+bootstrap: ~
+
 # This option defines where the task files and
 # directories reside.
 # The path is relative to this config file.

--- a/src/Configuration/Definition.php
+++ b/src/Configuration/Definition.php
@@ -19,6 +19,10 @@ class Definition implements ConfigurationInterface
 
             ->children()
 
+                ->scalarNode('bootstrap')
+                    ->info('Bootstrap file to use for closures' . PHP_EOL)
+                ->end()
+
                 ->scalarNode('source')
                     ->cannotBeEmpty()
                     ->info('path to the tasks directory' . PHP_EOL)

--- a/src/UserInterface/Cli/ClosureRunCommand.php
+++ b/src/UserInterface/Cli/ClosureRunCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Crunz\UserInterface\Cli;
 
 use Crunz\Application\Service\ClosureSerializerInterface;
+use Crunz\Application\Service\ConfigurationInterface;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,8 +16,12 @@ class ClosureRunCommand extends SymfonyCommand
     /** @var ClosureSerializerInterface */
     private $closureSerializer;
 
-    public function __construct(ClosureSerializerInterface $closureSerializer)
+    /** @var ConfigurationInterface */
+    private $configuration;
+
+    public function __construct(ClosureSerializerInterface $closureSerializer, ConfigurationInterface $configuration)
     {
+        $this->configuration     = $configuration;
         $this->closureSerializer = $closureSerializer;
 
         parent::__construct();
@@ -47,6 +52,11 @@ class ClosureRunCommand extends SymfonyCommand
     /** {@inheritdoc} */
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
+        $bootstrapFile = $this->configuration->get('bootstrap');
+        if ($bootstrapFile !== null) {
+            require_once $bootstrapFile;
+        }
+
         $args = [];
         /** @var string $closure */
         $closure = $input->getArgument('closure');

--- a/tests/Unit/UserInterface/Cli/bootstrap.php
+++ b/tests/Unit/UserInterface/Cli/bootstrap.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types=1);
+
+define('BOOTSTRAP_LOADED', true);


### PR DESCRIPTION
Allow loading of a bootstrap PHP file when running closures, useful to set up an environment without having to create a separate PHP file and run that file from the schedule file. With this you can just call a function in your app.
