### PR TITLE
Option to set config via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Crunz is capable of executing any kind of executable command as well as PHP clos
 To install it:
 
 ```bash
-composer require lavary/crunz
+composer require maartenvr98/crunz:dev-master -W
 ```
 If the installation is successful, a command-line utility named **crunz** is symlinked to the `vendor/bin` directory of your project.
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "dragonmantank/cron-expression": "^3.1",
         "opis/closure": "^3.5",
         "symfony/config": "^4.4 || ^5.2",
-        "symfony/console": "^4.4 || ^5.2",
+        "symfony/console": "^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.2",
         "symfony/filesystem": "^4.4 || ^5.2",
         "symfony/lock": "^4.4 || ^5.2",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         {
             "name": "Maartenvr98",
             "email": "contact@maartenvr98.nl"
-        },
+        }
     ],
     "support": {
         "email": "mrl.8081@gmail.com",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "lavary/crunz",
+    "name": "maartenvr98/crunz",
     "description": "Schedule your tasks right from the code.",
     "type": "library",
     "keywords": [
@@ -18,7 +18,11 @@
         {
             "name": "Reza M. Lavaryan",
             "email": "mrl.8081@gmail.com"
-        }
+        },
+        {
+            "name": "Maartenvr98",
+            "email": "contact@maartenvr98.nl"
+        },
     ],
     "support": {
         "email": "mrl.8081@gmail.com",

--- a/src/Application.php
+++ b/src/Application.php
@@ -77,7 +77,7 @@ class Application extends SymfonyApplication
         }
     }
 
-    public function run(InputInterface $input = null, OutputInterface $output = null)
+    public function run(InputInterface $input = null, OutputInterface $output = null): int
     {
         if (null === $output) {
             /** @var OutputInterface $outputObject */

--- a/src/Configuration/ConfigurationParser.php
+++ b/src/Configuration/ConfigurationParser.php
@@ -78,7 +78,10 @@ final class ConfigurationParser implements ConfigurationParserInterface
     {
         $cwd = $this->filesystem
             ->getCwd();
-        $configPath = Path::fromStrings($cwd ?? '', ConfigGeneratorCommand::CONFIG_FILE_NAME)->toString();
+        
+        $configFileName = getenv('CRUNZ_CONFIG') ?: ConfigGeneratorCommand::CONFIG_FILE_NAME;
+        
+        $configPath = Path::fromStrings($cwd ?? '', $configFileName)->toString();
         $configExists = $this->filesystem
             ->fileExists($configPath);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

I've created the short option to change the config file name via an environment variable. If nothing is set. Default config file name will be used. 

It can be used as follow: export CRUNZ_CONFIG=custom_config.yml && vendor/bin/crunz schedule:list.

It's a small fix but helps me a lot. 
