### PR TITLE
Option to set config via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [v3.1.0] - 2021-11-24
+
+### Changed
+
+- [#385] Replace `Swiftmailer` with `symfony/mailer`
+
 ## [v3.0.1] - 2021-05-25
 
 ### Fixed
@@ -323,6 +329,7 @@ In `v2` this will result in exception.
 
 - [#77] Fix high cpu usage
 
+[#385]: https://github.com/lavary/crunz/pull/385
 [#361]: https://github.com/lavary/crunz/pull/361
 [#356]: https://github.com/lavary/crunz/pull/356
 [#354]: https://github.com/lavary/crunz/pull/354

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Crunz is capable of executing any kind of executable command as well as PHP clos
 
 |Version|Supported PHP versions
 |---|---|
-|dev v3 (v3.1-dev)|![7.4+](https://img.shields.io/badge/php-%3E=7.4-blue.svg?style=flat-square)
-|stable v3 (v3.0.1)|![7.4+](https://img.shields.io/badge/php-%3E=7.4-blue.svg?style=flat-square)
+|dev v3 (v3.2-dev)|![7.4+](https://img.shields.io/badge/php-%3E=7.4-blue.svg?style=flat-square)
+|stable v3 (v3.1.0)|![7.4+](https://img.shields.io/badge/php-%3E=7.4-blue.svg?style=flat-square)
 |stable v2 (v2.3.1)|![7.2+](https://img.shields.io/badge/php-%3E=7.2-blue.svg?style=flat-square)
 |stable v1 (v1.12.4)|![5.6-7.0+](https://img.shields.io/badge/php-%5E5.6%20%7C%7C%20%5E7.0-blue.svg?style=flat-square)
 

--- a/composer.json
+++ b/composer.json
@@ -72,10 +72,5 @@
         "crunz:link-changelog": "@php vendor/bin/changelog-linker dump-merges --dry-run --in-categories",
         "crunz:link-changelog:since": "@php vendor/bin/changelog-linker dump-merges --dry-run --in-categories --since-id",
         "phpstan:check": "@php vendor/bin/phpstan analyse -c phpstan.neon src tests crunz config bootstrap.php"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "v3.1-dev"
-        }
     }
 }

--- a/src/Configuration/ConfigurationParser.php
+++ b/src/Configuration/ConfigurationParser.php
@@ -78,7 +78,10 @@ final class ConfigurationParser implements ConfigurationParserInterface
     {
         $cwd = $this->filesystem
             ->getCwd();
-        $configPath = Path::fromStrings($cwd ?? '', ConfigGeneratorCommand::CONFIG_FILE_NAME)->toString();
+        
+        $configFileName = getenv('CRUNZ_CONFIG') ?: ConfigGeneratorCommand::CONFIG_FILE_NAME;
+        
+        $configPath = Path::fromStrings($cwd ?? '', $configFileName)->toString();
         $configExists = $this->filesystem
             ->fileExists($configPath);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

I've created the short option to change the config file name via an environment variable. If nothing is set. Default config file name will be used.

It can be used as follow: export CRUNZ_CONFIG=custom_config.yml && vendor/bin/crunz schedule:list.

It's a small fix but helps me a lot.