### PR TITLE
Custom config path option

### DIFF
--- a/src/Configuration/ConfigurationParser.php
+++ b/src/Configuration/ConfigurationParser.php
@@ -78,7 +78,10 @@ final class ConfigurationParser implements ConfigurationParserInterface
     {
         $cwd = $this->filesystem
             ->getCwd();
-        $configPath = Path::fromStrings($cwd ?? '', ConfigGeneratorCommand::CONFIG_FILE_NAME)->toString();
+        
+        $configFileName = getenv('CRUNZ_CONFIG') ?: ConfigGeneratorCommand::CONFIG_FILE_NAME;
+        
+        $configPath = Path::fromStrings($cwd ?? '', $configFileName)->toString();
         $configExists = $this->filesystem
             ->fileExists($configPath);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

I've created the short option to change the config file name via an environment variable. If nothing is set. Default config file name will be used.

It can be used as follow: export CRUNZ_CONFIG=custom_config.yml && vendor/bin/crunz schedule:list.

It's a small fix but helps me a lot.
